### PR TITLE
Add support to array-organized JSON object

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -1,52 +1,62 @@
 /**
  *  Unbox - the easy to use Swift JSON decoder
  *
- *  For usage, see documentation of the classes/symbols listed in this file, as well
- *  as the guide available at: github.com/johnsundell/unbox
+ *  For usage, see documentation of the classes/symbols listed in this file, as
+ *  well as the guide available at: github.com/johnsundell/unbox
  *
- *  Copyright (c) 2015 John Sundell. Licensed under the MIT license, as follows:
+ *  Copyright (c) 2015 John Sundell. Manfred Lau. 
+ *  Licensed under the MIT license, as follows:
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
+ *  of this software and associated documentation files (the "Software"), to 
+ *  deal in the Software without restriction, including without limitation the 
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+ *  sell copies of the Software, and to permit persons to whom the Software is
  *  furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in all
- *  copies or substantial portions of the Software.
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
  *
  *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ *  IN THE SOFTWARE.
  */
 
 import Foundation
 
 /// Type alias defining what type of Dictionary that is Unboxable (valid JSON)
-public typealias UnboxableDictionary = [String : AnyObject]
+public typealias UnboxableDictionary    = [String : AnyObject]
+
+/// Type alias defining what type of Array that is Unboxable (valid JSON)
+public typealias UnboxableArray         = [UnboxableDictionary]
 
 // MARK: - Main Unbox functions
 
 /**
  *  Unbox (decode) a dictionary into a model
  *
- *  @param dictionary The dictionary to decode. Must be a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
+ *  @param      dictionary  The dictionary to decode. Must be a valid JSON
+ *  dictionary.
+ *  @param      context     Any contextual object that should be available
+ *  during unboxing.
  *
- *  @discussion This function gets its return type from the context in which it's called.
+ *  @discussion This function gets its return type from the context in which 
+ *  it's called.
  *  If the context is ambigious, you need to supply it, like:
  *
  *  `let unboxed: MyUnboxable? = Unbox(dictionary)`
  *
- *  @return A model of type `T` or `nil` if an error was occured. If you wish to know more
- *  about any error, use: `Unbox(dictionary, logErrors: true)`
+ *  @return     A model of type `T` or `nil` if an error was occured. If you
+ *  wish to know more about any error, use: `Unbox(dictionary, logErrors: true)`
  */
-public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: AnyObject? = nil) -> T? {
+public func Unbox<T: DictionaryUnboxable>(dictionary: UnboxableDictionary,
+    context: AnyObject? = nil)
+    -> T?
+{
     do {
         let unboxed: T = try UnboxOrThrow(dictionary, context: context)
         return unboxed
@@ -56,14 +66,71 @@ public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: AnyObj
 }
 
 /**
-*  Unbox (decode) a set of data into a model
-*
-*  @param data The data to decode. Must be convertible into a valid JSON dictionary.
-*  @param context Any contextual object that should be available during unboxing.
-*
-*  @discussion See the documentation for the main Unbox(dictionary:) function above for more information.
+ *  Unbox (decode) an array into a model
+ *
+ *  @param      array       The array to decode. Must be a valid JSON array.
+ *  @param      context     Any contextual object that should be available 
+ *  during unboxing.
+ *
+ *  @discussion This function gets its return type from the context in which
+ *  it's called.
+ *  If the context is ambigious, you need to supply it, like:
+ *
+ *  `let unboxed: MyUnboxable? = Unbox(array)`
+ *
+ *  @return     A model of type `T` or `nil` if an error was occured. If you
+ *  wish to know more about any error, use: `Unbox(array, logErrors: true)`
 */
-public func Unbox<T: Unboxable>(data: NSData, context: AnyObject? = nil) -> T? {
+public func Unbox<T: ArrayUnboxable>(array: UnboxableArray,
+    context: AnyObject? = nil)
+    -> T?
+{
+    do {
+        let unboxed: T = try UnboxOrThrow(array, context: context)
+        return unboxed
+    } catch {
+        return nil
+    }
+}
+
+/**
+ *  Unbox (decode) a set of data into a model
+ *
+ *  @param      data        The data to decode. Must be convertible into a valid
+ *  JSON dictionary.
+ *  @param      context     Any contextual object that should be available 
+ *  during unboxing.
+ *
+ *  @discussion See the documentation for the main Unbox(dictionary:) function 
+ *  above for more information.
+ */
+public func Unbox<T: DictionaryUnboxable>(data: NSData,
+    context: AnyObject? = nil)
+    -> T?
+{
+    do {
+        let unboxed: T = try UnboxOrThrow(data, context: context)
+        return unboxed
+    } catch {
+        return nil
+    }
+}
+
+/**
+ *  Unbox (decode) a set of data into a model
+ *
+ *  @param      data        The data to decode. Must be convertible into a valid
+ *  JSON array.
+ *  @param      context     Any contextual object that should be available
+ *  during unboxing.
+ *
+ *  @discussion See the documentation for the main Unbox(array:) function above
+ *  for more information.
+*/
+public func Unbox<T: ArrayUnboxable>(data: NSData,
+    context: AnyObject? = nil)
+    -> T?
+{
     do {
         let unboxed: T = try UnboxOrThrow(data, context: context)
         return unboxed
@@ -73,23 +140,31 @@ public func Unbox<T: Unboxable>(data: NSData, context: AnyObject? = nil) -> T? {
 }
 
 // MARK: - Unbox functions with error handling
-
 /**
- *  Unbox (decode) a dictionary into a model, or throw an UnboxError if the operation failed
+ *  Unbox (decode) a dictionary into a model, or throw an UnboxError if the 
+ *  operation failed
  *
- *  @param dictionary The dictionary to decode. Must be a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
+ *  @param      dictionary  The dictionary to decode. Must be a valid JSON
+ *  dictionary.
+ *  @param      context     Any contextual object that should be available 
+ *  during unboxing.
  *
- *  @discussion This function throws an UnboxError if the supplied dictionary couldn't be decoded
- *  for any reason. See the documentation for the main Unbox() function above for more information.
+ *  @discussion This function throws an UnboxError if the supplied dictionary 
+ *  couldn't be decoded for any reason. See the documentation for the main 
+ *  Unbox() function above for more information.
  */
-public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: AnyObject? = nil) throws -> T {
-    let unboxer = Unboxer(dictionary: dictionary, context: context)
+public func UnboxOrThrow<T: DictionaryUnboxable>(
+    dictionary: UnboxableDictionary,
+    context: AnyObject? = nil)
+    throws
+    -> T
+{
+    let unboxer = DictionaryUnboxer(dictionary: dictionary, context: context)
     let unboxed = T(unboxer: unboxer)
     
     if let failureInfo = unboxer.failureInfo {
         if let failedValue: AnyObject = failureInfo.value {
-            throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
+            throw UnboxError.InvalidKeyValue(failureInfo.key, "\(failedValue)")
         }
         
         throw UnboxError.MissingKey(failureInfo.key)
@@ -99,17 +174,70 @@ public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context:
 }
 
 /**
- *  Unbox (decode) a set of data into a model, or throw an UnboxError if the operation failed
+ *  Unbox (decode) an array into a model, or throw an UnboxError if the 
+ *  operation failed
  *
- *  @param data The data to decode. Must be convertible into a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
+ *  @param      array       The array to decode. Must be a valid JSON array.
+ *  @param      context     Any contextual object that should be available 
+ *  during unboxing.
  *
- *  @discussion This function throws an UnboxError if the supplied data couldn't be decoded for
- *  any reason. See the documentation for the main Unbox() function above for more information.
+ *  @discussion This function throws an UnboxError if the supplied array 
+ *  couldn't be decoded for any reason. See the documentation for the main 
+ *  Unbox() function above for more information.
  */
-public func UnboxOrThrow<T: Unboxable>(data: NSData, context: AnyObject? = nil) throws -> T {
-    if let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary {
+public func UnboxOrThrow<T: ArrayUnboxable>(array: UnboxableArray,
+    context: AnyObject? = nil)
+    throws
+    -> T
+{
+    let unboxer = ArrayUnboxer(array: array, context: context)
+    let unboxed = T(unboxer: unboxer)
+    
+    if let failureInfo = unboxer.failureInfo {
+        throw UnboxError.InvalidValue("\(failureInfo)")
+    }
+    
+    return unboxed
+}
+
+/**
+ *  Unbox (decode) a set of data into a model, or throw an UnboxError if the
+ *  operation failed
+ *
+ *  @param      data        The data to decode. Must be convertible into a valid
+ *  JSON dictionary.
+ *  @param      context     Any contextual object that should be available 
+ *  during unboxing.
+ *
+ *  @discussion This function throws an UnboxError if the supplied data couldn't
+ *  be decoded for any reason. See the documentation for the main Unbox() 
+ *  function above for more information.
+ */
+public func UnboxOrThrow<T: DictionaryUnboxable>(data: NSData,
+    context: AnyObject? = nil)
+    throws
+    -> T
+{
+    let rawJSONObject = try NSJSONSerialization
+        .JSONObjectWithData(data, options: [])
+    
+    if let dictionary = rawJSONObject as? UnboxableDictionary {
         return try UnboxOrThrow(dictionary)
+    }
+    
+    throw UnboxError.InvalidDictionary
+}
+
+public func UnboxOrThrow<T: ArrayUnboxable>(data: NSData,
+    context: AnyObject? = nil)
+    throws
+    -> T
+{
+    let rawJSONObject = try NSJSONSerialization
+        .JSONObjectWithData(data, options: [])
+    
+    if let array = rawJSONObject as? UnboxableArray {
+        return try UnboxOrThrow(array)
     }
     
     throw UnboxError.InvalidDictionary
@@ -117,7 +245,8 @@ public func UnboxOrThrow<T: Unboxable>(data: NSData, context: AnyObject? = nil) 
 
 // MARK: - Error type
 
-/// Enum describing errors that can occur during unboxing. Use the throwing functions to receive any errors.
+/// Enum describing errors that can occur during unboxing. Use the throwing
+/// functions to receive any errors.
 public enum UnboxError: ErrorType, CustomStringConvertible {
     public var description: String {
         let baseDescription = "[Unbox error] "
@@ -125,33 +254,57 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
         switch self {
         case .MissingKey(let key):
             return baseDescription + "Missing key (\(key))"
-        case .InvalidValue(let key, let valueDescription):
-            return baseDescription + "Invalid value (\(valueDescription)) for key (\(key))"
+        case .InvalidKeyValue(let key, let valueDescription):
+            return baseDescription
+                + "Invalid value (\(valueDescription)) for key (\(key))"
+        case .InvalidValue(let valueDescription):
+            return baseDescription + "Invalid value (\(valueDescription))"
         case .InvalidDictionary:
             return "Invalid dictionary"
         }
     }
     
-    /// Thrown when a required key was missing in an unboxed dictionary. Contains the missing key.
+    /// Thrown when a required key was missing in an unboxed dictionary. 
+    /// Contains the missing key.
     case MissingKey(String)
-    /// Thrown when a required key contained an invalid value in an unboxed dictionary. Contains the invalid
-    /// key and a description of the invalid data.
-    case InvalidValue(String, String)
-    /// Thrown when an unboxed dictionary was either missing or contained invalid data
+    /// Thrown when a required key contained an invalid value in an unboxed 
+    /// dictionary. Contains the invalid key and a description of the invalid
+    /// data.
+    case InvalidKeyValue(String, String)
+    /// Thrown when an array contained an invalid value in an unboxed array.
+    /// Contains the description of the invalid data.
+    case InvalidValue(String)
+    /// Thrown when an unboxed dictionary was either missing or contained 
+    /// invalid data
     case InvalidDictionary
 }
 
 // MARK: - Protocols
-
-/// Protocol used to declare a model as being Unboxable, for use with the Unbox() function
 public protocol Unboxable {
-    /// Initialize an instance of this model by unboxing a dictionary using an Unboxer
-    init(unboxer: Unboxer)
+    
 }
 
-/// Protocol used to enable a raw type for Unboxing. See default implementations further down.
+/// Protocol used to declare a model as being DictionaryUnboxable, for use with
+/// the Unbox() function
+public protocol DictionaryUnboxable: Unboxable {
+    /// Initialize an instance of this model by unboxing a dictionary using an 
+    /// DictionaryUnboxer
+    init(unboxer: DictionaryUnboxer)
+}
+
+/// Protocol used to declare a model as being ArrayUnboxable, for use with the
+/// Unbox() function
+public protocol ArrayUnboxable: Unboxable {
+    /// Initialize an instance of this model by unboxing an array using an 
+    /// ArrayUnboxer
+    init(unboxer: ArrayUnboxer)
+}
+
+/// Protocol used to enable a raw type for Unboxing. See default implementations
+/// further down.
 public protocol UnboxableRawType {
-    /// The value to use for required properties if unboxing failed. This value will never be returned to the API user.
+    /// The value to use for required properties if unboxing failed. This value
+    /// will never be returned to the API user.
     static func fallbackValue() -> Self
 }
 
@@ -161,17 +314,20 @@ public protocol UnboxableByTransform {
     typealias UnboxTransformerType: UnboxTransformer
 }
 
-/// Protocol for objects that can act as Unboxing transformers, turning an unboxed value into its final form
+/// Protocol for objects that can act as Unboxing transformers, turning an 
+/// unboxed value into its final form
 public protocol UnboxTransformer {
     /// The raw unboxed type this transformer accepts as input
     typealias RawType
     /// The transformed type this transformer outputs
     typealias TransformedType
     
-    /// Attempt to transformed an unboxed value, returning non-`nil` if successful
+    /// Attempt to transformed an unboxed value, returning non-`nil` if
+    /// successful
     static func transformUnboxedValue(unboxedValue: RawType) -> TransformedType?
     
-    /// The value to use for required properties if unboxing or transformation failed. This value will never be returned to the API user.
+    /// The value to use for required properties if unboxing or transformation 
+    /// failed. This value will never be returned to the API user.
     static func fallbackValue() -> TransformedType
 }
 
@@ -219,7 +375,9 @@ public class UnboxURLTransformer: UnboxTransformer {
     public typealias RawType = String
     public typealias TransformedType = NSURL
     
-    public static func transformUnboxedValue(unboxedValue: RawType) -> TransformedType? {
+    public static func transformUnboxedValue(unboxedValue: RawType)
+        -> TransformedType?
+    {
         return NSURL(string: unboxedValue)
     }
     
@@ -234,122 +392,230 @@ extension NSURL: UnboxableByTransform {
 }
 
 // MARK: - Unboxer
+private protocol UnboxerType {
+    /// Whether the Unboxer has failed, and a `nil` value will be returned
+    /// from the `Unbox()` function that triggered it.
+    var hasFailed: Bool { get }
+    
+    /// Any contextual object that was supplied when unboxing was started
+    var context: AnyObject? { get }
+}
+
+/**
+ *  Class used to Unbox (decode) values from an array
+ *
+ *  For each supported type, simply call `unbox(key)` and the correct type will
+ *  be returned. If a required (non-optional) value couldn't be unboxed, the
+ *  Unboxer will be marked as failed, and a `nil` value will be returned from
+ *  the `Unbox()` function that triggered the Unboxer.
+ *
+ *  An ArrayUnboxer may also be manually failed, by using the 
+ * `failForInvalidValue()` API.
+*/
+public class ArrayUnboxer: UnboxerType {
+    private let array: UnboxableArray
+    
+    public var hasFailed: Bool { return self.failureInfo != nil }
+    private let context: AnyObject?
+    
+    private var failureInfo: UnboxableDictionary?
+    
+    // MARK: - Private initializer
+    
+    private init(array: UnboxableArray, context: AnyObject?) {
+        self.array = array; self.context = context
+    }
+    
+    /// Unbox self as an array
+    public func unbox<T: DictionaryUnboxable>() -> [T] {
+        return array.flatMap { Unbox($0, context: self.context) }
+    }
+    
+    public  func failForInvalidValue(value: UnboxableDictionary) {
+        failureInfo = value
+    }
+}
 
 /**
  *  Class used to Unbox (decode) values from a dictionary
  *
- *  For each supported type, simply call `unbox(key)` and the correct type will be returned. If a required (non-optional)
- *  value couldn't be unboxed, the Unboxer will be marked as failed, and a `nil` value will be returned from the `Unbox()`
- *  function that triggered the Unboxer.
+ *  For each supported type, simply call `unbox(key)` and the correct type will
+ *  be returned. If a required (non-optional) value couldn't be unboxed, the 
+ *  Unboxer will be marked as failed, and a `nil` value will be returned from 
+ *  the `Unbox()` function that triggered the Unboxer.
  *
- *  An Unboxer may also be manually failed, by using the `failForKey()` or `failForInvalidValue(forKey:)` APIs.
+ *  An DictionaryUnboxer may also be manually failed, by using the 
+ *  `failForKey()` or `failForInvalidValue(forKey:)` APIs.
  */
-public class Unboxer {
-    /// Whether the Unboxer has failed, and a `nil` value will be returned from the `Unbox()` function that triggered it.
-    public var hasFailed: Bool { return self.failureInfo != nil }
-    /// Any contextual object that was supplied when unboxing was started
-    public let context: AnyObject?
-    
-    private var failureInfo: (key: String, value: AnyObject?)?
+public class DictionaryUnboxer: UnboxerType {
     private let dictionary: UnboxableDictionary
+    
+    public var hasFailed: Bool { return self.failureInfo != nil }
+    private let context: AnyObject?
+    
+    public private(set) var failureInfo: (key: String, value: AnyObject?)?
     
     // MARK: - Private initializer
     
     private init(dictionary: UnboxableDictionary, context: AnyObject?) {
-        self.dictionary = dictionary
-        self.context = context
+        self.dictionary = dictionary; self.context = context
     }
-    
-    // MARK: - Public API
     
     /// Unbox a required raw type
     public func unbox<T: UnboxableRawType>(key: String) -> T {
-        return UnboxValueResolver<T>(self).resolveRequiredValueForKey(key, fallbackValue: T.fallbackValue())
+        return DictionaryUnboxValueResolver<T>(self)
+            .resolveRequiredValueForKey(key, fallbackValue: T.fallbackValue())
     }
     
     /// Unbox an optional raw type
     public func unbox<T: UnboxableRawType>(key: String) -> T? {
-        return UnboxValueResolver<T>(self).resolveOptionalValueForKey(key)
+        return DictionaryUnboxValueResolver<T>(self)
+            .resolveOptionalValueForKey(key)
     }
     
     /// Unbox a required Array
     public func unbox<T>(key: String) -> [T] {
-        return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, fallbackValue: [])
+        return DictionaryUnboxValueResolver<[T]>(self)
+            .resolveRequiredValueForKey(key, fallbackValue: [])
     }
     
     /// Unbox an optional Array
     public func unbox<T>(key: String) -> [T]? {
-        return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key)
+        return DictionaryUnboxValueResolver<[T]>(self)
+            .resolveOptionalValueForKey(key)
     }
     
     /// Unbox a required Dictionary
     public func unbox<T>(key: String) -> [String : T] {
-        return UnboxValueResolver<[String : T]>(self).resolveRequiredValueForKey(key, fallbackValue: [:])
+        return DictionaryUnboxValueResolver<[String : T]>(self)
+            .resolveRequiredValueForKey(key, fallbackValue: [:])
     }
     
     /// Unbox an optional Dictionary
     public func unbox<T>(key: String) -> [String : T]? {
-        return UnboxValueResolver<[String : T]>(self).resolveOptionalValueForKey(key)
+        return DictionaryUnboxValueResolver<[String : T]>(self)
+            .resolveOptionalValueForKey(key)
     }
     
-    /// Unbox a required nested Unboxable, by unboxing a Dictionary and then using a transform
-    public func unbox<T: Unboxable>(key: String) -> T {
-        return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: T(unboxer: self), transform: {
-            return Unbox($0, context: self.context)
+    /// Unbox a required nested Unboxable, by unboxing a Dictionary and then 
+    /// using a transform
+    public func unbox<T: DictionaryUnboxable>(key: String) -> T {
+        return DictionaryUnboxValueResolver<UnboxableDictionary>(self)
+            .resolveRequiredValueForKey(key,
+                fallbackValue: T(unboxer: self),
+                transform: {return Unbox($0, context: self.context)})
+    }
+    
+    /// Unbox an optional nested Unboxable, by unboxing a Dictionary and then 
+    /// using a transform
+    public func unbox<T: DictionaryUnboxable>(key: String) -> T? {
+        return DictionaryUnboxValueResolver<UnboxableDictionary>(self)
+            .resolveOptionalValueForKey(key,
+                transform: { return Unbox($0, context: self.context) })
+    }
+    
+    /// Unbox a required Array of nested Unboxables, by unboxing an Array of 
+    /// Dictionaries and then using a transform
+    public func unbox<T: DictionaryUnboxable>(key: String) -> [T] {
+        return DictionaryUnboxValueResolver<[UnboxableDictionary]>(self)
+            .resolveRequiredValueForKey(key,
+                fallbackValue: [],
+                transform: {
+                    return self.transformUnboxableDictionaryToArray($0,
+                        forKey: key, 
+                        required: true)
         })
     }
     
-    /// Unbox an optional nested Unboxable, by unboxing a Dictionary and then using a transform
-    public func unbox<T: Unboxable>(key: String) -> T? {
-        return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, transform: {
-            return Unbox($0, context: self.context)
+    /// Unbox an optional Array of nested Unboxables, by unboxing an Array of 
+    /// Dictionaries and then using a transform
+    public func unbox<T: DictionaryUnboxable>(key: String) -> [T]? {
+        return DictionaryUnboxValueResolver<[UnboxableDictionary]>(self)
+            .resolveOptionalValueForKey(key,
+                transform: {
+                    return self.transformUnboxableDictionaryToArray($0,
+                        forKey: key,
+                        required: false)
         })
     }
     
-    /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
-    public func unbox<T: Unboxable>(key: String) -> [T] {
-        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, fallbackValue: [], transform: {
-            return self.transformUnboxableDictionaryArray($0, forKey: key, required: true)
+    /// Unbox a required Dictionary of nested Unboxables, by unboxing an 
+    /// Dictionary of Dictionaries and then using a transform
+    public func unbox<T: DictionaryUnboxable>(key: String) -> [String : T] {
+        return DictionaryUnboxValueResolver<UnboxableDictionary>(self)
+            .resolveRequiredValueForKey(key,
+                fallbackValue: [:],
+                transform: {
+                    return self.transformUnboxableDictionaryToDictionary($0,
+                        required: true)
         })
     }
     
-    /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
-    public func unbox<T: Unboxable>(key: String) -> [T]? {
-        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, transform: {
-            return self.transformUnboxableDictionaryArray($0, forKey: key, required: false)
+    /// Unbox an optional Dictionary of nested Unboxables, by unboxing an 
+    /// Dictionary of Dictionaries and then using a transform
+    public func unbox<T: DictionaryUnboxable>(key: String) -> [String : T]? {
+        return DictionaryUnboxValueResolver<UnboxableDictionary>(self)
+            .resolveOptionalValueForKey(key,
+                transform: {
+                    return self.transformUnboxableDictionaryToDictionary($0,
+                        required: false)
         })
     }
     
-    /// Unbox a required Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<T: Unboxable>(key: String) -> [String : T] {
-        return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: [:], transform: {
-            return self.transformUnboxableDictionaryDictionary($0, required: true)
+    /// Unbox a required value that can be transformed into its final form. 
+    /// Usable for types that have an `UnboxTransformer`
+    public func unbox<T: UnboxableByTransform
+        where T == T.UnboxTransformerType.TransformedType>
+        (key: String)
+        -> T
+    {
+        return DictionaryUnboxValueResolver
+            <T.UnboxTransformerType.RawType>(self)
+            .resolveRequiredValueForKey(key,
+                fallbackValue: T.UnboxTransformerType.fallbackValue(),
+                transform: {
+                    return T.UnboxTransformerType.transformUnboxedValue($0)
         })
     }
     
-    /// Unbox an optional Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<T: Unboxable>(key: String) -> [String : T]? {
-        return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, transform: {
-            return self.transformUnboxableDictionaryDictionary($0, required: false)
+    /// Unbox an optional value that can be transformed into its final form. 
+    /// Usable for types that have an `UnboxTransformer`
+    public func unbox<T: UnboxableByTransform
+        where T == T.UnboxTransformerType.TransformedType>
+        (key: String)
+        -> T.UnboxTransformerType.TransformedType?
+    {
+        return DictionaryUnboxValueResolver
+            <T.UnboxTransformerType.RawType>(self)
+            .resolveOptionalValueForKey(key,
+                transform: {
+                    return T.UnboxTransformerType.transformUnboxedValue($0)
         })
     }
     
-    /// Unbox a required value that can be transformed into its final form. Usable for types that have an `UnboxTransformer`
-    public func unbox<T: UnboxableByTransform where T == T.UnboxTransformerType.TransformedType>(key: String) -> T {
-        return UnboxValueResolver<T.UnboxTransformerType.RawType>(self).resolveRequiredValueForKey(key, fallbackValue: T.UnboxTransformerType.fallbackValue(), transform: {
-            return T.UnboxTransformerType.transformUnboxedValue($0)
-        })
+    // MARK: Private utilities
+    /// Make this Unboxer to fail for a certain key. This will cause the 
+    /// `Unbox()` function that triggered this Unboxer to return `nil`.
+    public func failForKey(key: String) {
+        self.failForInvalidValue(nil, forKey: key)
     }
     
-    /// Unbox an optional value that can be transformed into its final form. Usable for types that have an `UnboxTransformer`
-    public func unbox<T: UnboxableByTransform where T == T.UnboxTransformerType.TransformedType>(key: String) -> T.UnboxTransformerType.TransformedType? {
-        return UnboxValueResolver<T.UnboxTransformerType.RawType>(self).resolveOptionalValueForKey(key, transform: {
-            return T.UnboxTransformerType.transformUnboxedValue($0)
-        })
+    /// Make this Unboxer to fail for a certain key and invalid value. This will
+    /// cause the `Unbox()` function that triggered this Unboxer to return 
+    /// `nil`.
+    public func failForInvalidValue(invalidValue: AnyObject?,
+        forKey key: String)
+    {
+        self.failureInfo = (key, invalidValue)
     }
     
-    /// Return a required contextual object of type `T` attached to this Unboxer, or cause the Unboxer to fail (using a dummy fallback value)
-    public func requiredContextWithFallbackValue<T>(@autoclosure fallbackValue: () -> T) -> T {
+    
+    /// Return a required contextual object of type `T` attached to this 
+    /// Unboxer, or cause the Unboxer to fail (using a dummy fallback value)
+    private func requiredContextWithFallbackValue<T>(
+        @autoclosure fallbackValue: () -> T)
+        -> T
+    {
         if let context = self.context as? T {
             return context
         }
@@ -359,19 +625,12 @@ public class Unboxer {
         return fallbackValue()
     }
     
-    /// Make this Unboxer to fail for a certain key. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
-    public func failForKey(key: String) {
-        self.failForInvalidValue(nil, forKey: key)
-    }
-    
-    /// Make this Unboxer to fail for a certain key and invalid value. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
-    public func failForInvalidValue(invalidValue: AnyObject?, forKey key: String) {
-        self.failureInfo = (key, invalidValue)
-    }
-    
-    // MARK: - Private utilities
-    
-    private func transformUnboxableDictionaryArray<T: Unboxable>(dictionaries: [UnboxableDictionary], forKey key: String, required: Bool) -> [T]? {
+    private func transformUnboxableDictionaryToArray<T: DictionaryUnboxable>(
+        dictionaries: [UnboxableDictionary],
+        forKey key: String,
+        required: Bool)
+        -> [T]?
+    {
         var transformed = [T]()
         
         for dictionary in dictionaries {
@@ -385,15 +644,20 @@ public class Unboxer {
         return transformed
     }
     
-    private func transformUnboxableDictionaryDictionary<T: Unboxable>(dictionaries: UnboxableDictionary, required: Bool) -> [String : T]? {
+    private func transformUnboxableDictionaryToDictionary
+        <T: DictionaryUnboxable>
+        (dictionaries: UnboxableDictionary,
+        required: Bool)
+        -> [String : T]?
+    {
         var transformed = [String : T]()
         
         for (key, dictionary) in dictionaries {
-            if let unboxableDictionary = dictionary as? UnboxableDictionary {
-                if let unboxed: T = Unbox(unboxableDictionary, context: self.context) {
-                    transformed[key] = unboxed
-                    continue
-                }
+            if let unboxableDictionary = dictionary as? UnboxableDictionary,
+                unboxed: T = Unbox(unboxableDictionary, context: self.context)
+            {
+                transformed[key] = unboxed
+                continue
             }
             
             if required {
@@ -406,26 +670,35 @@ public class Unboxer {
 }
 
 // MARK: - UnboxValueResolver
-
-private class UnboxValueResolver<T> {
-    let unboxer: Unboxer
+private class DictionaryUnboxValueResolver<T> {
+    let unboxer: DictionaryUnboxer
     
-    init(_ unboxer: Unboxer) {
+    init(_ unboxer: DictionaryUnboxer) {
         self.unboxer = unboxer
     }
     
-    func resolveRequiredValueForKey(key: String, @autoclosure fallbackValue: () -> T) -> T {
-        return self.resolveRequiredValueForKey(key, fallbackValue: fallbackValue, transform: {
-            return $0
-        })
+    func resolveRequiredValueForKey(key: String,
+        @autoclosure fallbackValue: () -> T)
+        -> T
+    {
+        return self.resolveRequiredValueForKey(key,
+            fallbackValue: fallbackValue,
+            transform: { return $0 })
     }
     
-    func resolveRequiredValueForKey<R>(key: String, @autoclosure fallbackValue: () -> R, transform: T -> R?) -> R {
-        if let value = self.resolveOptionalValueForKey(key, transform: transform) {
+    func resolveRequiredValueForKey<R>(key: String,
+        @autoclosure fallbackValue: () -> R,
+        transform: T -> R?)
+        -> R
+    {
+        if let value = self.resolveOptionalValueForKey(key,
+            transform: transform)
+        {
             return value
         }
         
-        self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
+        self.unboxer.failForInvalidValue(self.unboxer.dictionary[key],
+            forKey: key)
         
         return fallbackValue()
     }
@@ -446,3 +719,4 @@ private class UnboxValueResolver<T> {
         return nil
     }
 }
+

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -106,7 +106,7 @@ class UnboxTests: XCTestCase {
             do {
                 let _: UnboxTestMock = try UnboxOrThrow(invalidDictionary)
                 XCTFail("Unbox should have thrown for an invalid value")
-            } catch UnboxError.InvalidValue(key, invalidValueDescription) {
+            } catch UnboxError.InvalidKeyValue(key, invalidValueDescription) {
                 // Test passed
             } catch {
                 XCTFail("Unbox did not return the correct error type")
@@ -131,10 +131,10 @@ class UnboxTests: XCTestCase {
     }
     
     func testContext() {
-        class UnboxableWithContext: Unboxable {
+        class UnboxableWithContext: DictionaryUnboxable {
             let nestedUnboxable: UnboxableWithContext?
             
-            required init(unboxer: Unboxer) {
+            required init(unboxer: DictionaryUnboxer) {
                 if let context = unboxer.context as? String {
                     XCTAssertTrue("context" == context, "")
                 } else {
@@ -173,7 +173,7 @@ private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool)
 
 // MARK: - Mocks
 
-private class UnboxTestBaseMock: Unboxable {
+private class UnboxTestBaseMock: DictionaryUnboxable {
     static let requiredBoolKey = "requiredBool"
     static let optionalBoolKey = "optionalBool"
     static let requiredIntKey = "requiredInt"
@@ -204,7 +204,7 @@ private class UnboxTestBaseMock: Unboxable {
     let requiredArray: [String]
     let optionalArray: [String]?
     
-    required init(unboxer: Unboxer) {
+    required init(unboxer: DictionaryUnboxer) {
         self.requiredBool = unboxer.unbox(UnboxTestBaseMock.requiredBoolKey)
         self.optionalBool = unboxer.unbox(UnboxTestBaseMock.optionalBoolKey)
         self.requiredInt = unboxer.unbox(UnboxTestBaseMock.requiredIntKey)
@@ -312,7 +312,7 @@ private class UnboxTestMock: UnboxTestBaseMock {
     let requiredUnboxableDictionary: [String : UnboxTestBaseMock]
     let optionalUnboxableDictionary: [String : UnboxTestBaseMock]?
     
-    required init(unboxer: Unboxer) {
+    required init(unboxer: DictionaryUnboxer) {
         self.requiredUnboxable = unboxer.unbox(UnboxTestMock.requiredUnboxableKey)
         self.optionalUnboxable = unboxer.unbox(UnboxTestMock.optionalUnboxableKey)
         self.requiredUnboxableArray = unboxer.unbox(UnboxTestMock.requiredUnboxableArrayKey)


### PR DESCRIPTION
The original implementation of Unboxer always requires a key to decode a JSON key-value combination, which causes it cannot handle an array-organized JSON object such as:
rootObject = [
 ["Key1" : "Value 1"],
 ["Key2" : "Value 2"],
 ["Key3" : "Value 3"],
]

I just split the Unboxer into DictionaryUnboxer to achieve the original Unboxer's design purpose and ArrayUnboxer to support decoding of array-organized JSON object. At the same time, Unboxable was split into DictionaryUnboxable and ArrayUnboxable.

To decode an array-organized JSON object, just make your type to conform to ArrayUnboxable and use ArrayUnboxer's unbox() function to decode the array.

Plus, I applied the Unbox.swift with 80-character line length constraint.