### PR TITLE
Unboxing by key path

### DIFF
--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -149,6 +149,33 @@ class UnboxTests: XCTestCase {
         
         XCTAssertFalse(unboxed == nil, "Could not unbox with a context")
     }
+
+    func testAccessingNestedDictionaryWithKeyPath() {
+        struct KeyPathModel: Unboxable {
+            let intValue: Int
+            let dictionary: UnboxableDictionary
+
+            init(unboxer: Unboxer) {
+                let intKeyPathComponents = [UnboxTestMock.requiredUnboxableDictionaryKey, "test", UnboxTestMock.requiredIntKey]
+                let keyPath = intKeyPathComponents.joinWithSeparator(".")
+                intValue = unboxer.unbox(keyPath)
+
+                let dictionaryKeyPath = [UnboxTestMock.requiredUnboxableDictionaryKey, "test"].joinWithSeparator(".")
+                dictionary = unboxer.unbox(dictionaryKeyPath)
+            }
+        }
+
+
+        let validDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
+        let model: KeyPathModel? = Unbox(validDictionary)
+        XCTAssertNotNil(model)
+        XCTAssertEqual(15, model?.intValue)
+        if let result = model?.dictionary[UnboxTestMock.requiredArrayKey] as? [String] {
+            XCTAssertEqual(["unbox", "is", "pretty", "cool", "right?"], result)
+        } else {
+            XCTFail()
+        }
+    }
 }
 
 private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool) -> UnboxableDictionary {


### PR DESCRIPTION
Hi! Pretty cool idea with type inference for JSON parsing.

Started using Unbox and run into a situation where JSON structure doesn’t directly map to model. For example there's a bunch of nested dictionaries, one of them has the value I need. Didn't find a way to access it without nesting models. I’ve baked up a solution using key paths. Data can be unboxed like this:

```swift
struct KeyPathModel: Unboxable {
    let intValue: Int
    let dictionary: UnboxableDictionary

    init(unboxer: Unboxer) {
        intValue = unboxer.unbox("requiredUnboxableDictionary.test.requiredInt")
        dictionary = unboxer.unbox("requiredUnboxableDictionary.test.")
    }
}
```

One detail: if any, but last, key path component along the way references something other than dictionary, unboxing returns `nil`.

Gets the job done for me, maybe someone else can find it useful.