### PR TITLE
Unbox 1.1

### DIFF
--- a/Unbox.podspec
+++ b/Unbox.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Unbox"
-  s.version      = "1.0"
+  s.version      = "1.1"
   s.summary      = "The easy to use Swift JSON decoder."
   s.description  = <<-DESC
     Unbox is an easy to use Swift JSON decoder. Don't spend hours writing JSON decoding code - just unbox it instead!
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
-  s.source       = { :git => "https://github.com/JohnSundell/Unbox.git", :tag => "1.0" }
+  s.source       = { :git => "https://github.com/JohnSundell/Unbox.git", :tag => "1.1" }
   s.source_files  = "Unbox.swift"
   s.framework  = "Foundation"
 end

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -570,3 +570,17 @@ extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConver
         return [:]
     }
 }
+
+// MARK: - Private extensions
+
+private extension Unboxable {
+    static func unboxFallbackValue() -> Self {
+        return self.init(unboxer: Unboxer(dictionary: [:], context: nil))
+    }
+}
+
+private extension UnboxableWithContext {
+    static func unboxFallbackValueWithContext(context: ContextType) -> Self {
+        return self.init(unboxer: Unboxer(dictionary: [:], context: context), context: context)
+    }
+}

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -169,35 +169,35 @@ public protocol UnboxableByTransform: UnboxCompatibleType {
 
 // MARK: - Raw types
 
-/// Protocol making Bool an Unboxable raw type
+/// Extension making Bool an Unboxable raw type
 extension Bool: UnboxableRawType {
     public static func unboxFallbackValue() -> Bool {
         return false
     }
 }
 
-/// Protocol making Int an Unboxable raw type
+/// Extension making Int an Unboxable raw type
 extension Int: UnboxableRawType {
     public static func unboxFallbackValue() -> Int {
         return 0
     }
 }
 
-/// Protocol making Double an Unboxable raw type
+/// Extension making Double an Unboxable raw type
 extension Double: UnboxableRawType {
     public static func unboxFallbackValue() -> Double {
         return 0
     }
 }
 
-/// Protocol making Float an Unboxable raw type
+/// Extension making Float an Unboxable raw type
 extension Float: UnboxableRawType {
     public static func unboxFallbackValue() -> Float {
         return 0
     }
 }
 
-/// Protocol making String an Unboxable raw type
+/// Extension making String an Unboxable raw type
 extension String: UnboxableRawType {
     public static func unboxFallbackValue() -> String {
         return ""
@@ -206,7 +206,7 @@ extension String: UnboxableRawType {
 
 // MARK: - Default transformation implementations
 
-/// Protocol making NSURL Unboxable by transform
+/// Extension making NSURL Unboxable by transform
 extension NSURL: UnboxableByTransform {
     public typealias UnboxRawValueType = String
     

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -151,7 +151,7 @@ public protocol Unboxable {
 
 /// Protocol used to enable a raw type for Unboxing. See default implementations further down.
 public protocol UnboxableRawType {
-    /// The value to use for required properties if unboxing failed. This value will never be returned to the API user.
+    /// The value to use for required properties if unboxing failed. Typically a dummy value.
     static func unboxFallbackValue() -> Self
 }
 

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -408,6 +408,20 @@ public class Unboxer {
         })
     }
     
+    /// Unbox a required nested UnboxableWithContext type
+    public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> T {
+        return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValueWithContext(context), transform: {
+            return Unbox($0, context: context)
+        })
+    }
+    
+    /// Unbox an optional nested UnboxableWithContext type
+    public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> T? {
+        return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, transform: {
+            return Unbox($0, context: context)
+        })
+    }
+    
     /// Unbox a required value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String) -> T {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -152,7 +152,7 @@ public protocol Unboxable {
 /// Protocol used to enable a raw type for Unboxing. See default implementations further down.
 public protocol UnboxableRawType {
     /// The value to use for required properties if unboxing failed. This value will never be returned to the API user.
-    static func fallbackValue() -> Self
+    static func unboxFallbackValue() -> Self
 }
 
 /// Protocol used to declare a model as being Unboxable by using a transformer
@@ -179,35 +179,35 @@ public protocol UnboxTransformer {
 
 /// Protocol making Bool an Unboxable raw type
 extension Bool: UnboxableRawType {
-    public static func fallbackValue() -> Bool {
+    public static func unboxFallbackValue() -> Bool {
         return false
     }
 }
 
 /// Protocol making Int an Unboxable raw type
 extension Int: UnboxableRawType {
-    public static func fallbackValue() -> Int {
+    public static func unboxFallbackValue() -> Int {
         return 0
     }
 }
 
 /// Protocol making Double an Unboxable raw type
 extension Double: UnboxableRawType {
-    public static func fallbackValue() -> Double {
+    public static func unboxFallbackValue() -> Double {
         return 0
     }
 }
 
 /// Protocol making Float an Unboxable raw type
 extension Float: UnboxableRawType {
-    public static func fallbackValue() -> Float {
+    public static func unboxFallbackValue() -> Float {
         return 0
     }
 }
 
 /// Protocol making String an Unboxable raw type
 extension String: UnboxableRawType {
-    public static func fallbackValue() -> String {
+    public static func unboxFallbackValue() -> String {
         return ""
     }
 }
@@ -262,7 +262,7 @@ public class Unboxer {
     
     /// Unbox a required raw type
     public func unbox<T: UnboxableRawType>(key: String) -> T {
-        return UnboxValueResolver<T>(self).resolveRequiredValueForKey(key, fallbackValue: T.fallbackValue())
+        return UnboxValueResolver<T>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue())
     }
     
     /// Unbox an optional raw type

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -450,17 +450,6 @@ public class Unboxer {
         })
     }
     
-    /// Return a required contextual object of type `T` attached to this Unboxer, or cause the Unboxer to fail (using a dummy fallback value)
-    public func requiredContextWithFallbackValue<T>(@autoclosure fallbackValue: () -> T) -> T {
-        if let context = self.context as? T {
-            return context
-        }
-        
-        self.failForInvalidValue(self.context, forKey: "Unboxer.Context")
-        
-        return fallbackValue()
-    }
-    
     /// Make this Unboxer to fail for a certain key. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForKey(key: String) {
         self.failForInvalidValue(nil, forKey: key)

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -46,7 +46,7 @@ public typealias UnboxableDictionary = [String : AnyObject]
  *  @return A model of type `T` or `nil` if an error was occured. If you prefer do, try, catch
  *  error handling instead of optionals; use `UnboxOrThrow` instead.
  */
-public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: AnyObject? = nil) -> T? {
+public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
     do {
         let unboxed: T = try UnboxOrThrow(dictionary, context: context)
         return unboxed
@@ -56,14 +56,14 @@ public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: AnyObj
 }
 
 /**
-*  Unbox (decode) a set of data into a model
-*
-*  @param data The data to decode. Must be convertible into a valid JSON dictionary.
-*  @param context Any contextual object that should be available during unboxing.
-*
-*  @discussion See the documentation for the main Unbox(dictionary:) function above for more information.
-*/
-public func Unbox<T: Unboxable>(data: NSData, context: AnyObject? = nil) -> T? {
+ *  Unbox (decode) a set of data into a model
+ *
+ *  @param data The data to decode. Must be convertible into a valid JSON dictionary.
+ *  @param context Any contextual object that should be available during unboxing.
+ *
+ *  @discussion See the documentation for the main Unbox(dictionary:) function above for more information.
+ */
+public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
     do {
         let unboxed: T = try UnboxOrThrow(data, context: context)
         return unboxed
@@ -83,12 +83,12 @@ public func Unbox<T: Unboxable>(data: NSData, context: AnyObject? = nil) -> T? {
  *  @discussion This function throws an UnboxError if the supplied dictionary couldn't be decoded
  *  for any reason. See the documentation for the main Unbox() function above for more information.
  */
-public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: AnyObject? = nil) throws -> T {
+public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
     let unboxer = Unboxer(dictionary: dictionary, context: context)
     let unboxed = T(unboxer: unboxer)
     
     if let failureInfo = unboxer.failureInfo {
-        if let failedValue: AnyObject = failureInfo.value {
+        if let failedValue: Any = failureInfo.value {
             throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
         }
         
@@ -107,7 +107,7 @@ public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context:
  *  @discussion This function throws an UnboxError if the supplied data couldn't be decoded for
  *  any reason. See the documentation for the main Unbox() function above for more information.
  */
-public func UnboxOrThrow<T: Unboxable>(data: NSData, context: AnyObject? = nil) throws -> T {
+public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
     if let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary {
         return try UnboxOrThrow(dictionary)
     }
@@ -246,14 +246,14 @@ public class Unboxer {
     /// Whether the Unboxer has failed, and a `nil` value will be returned from the `Unbox()` function that triggered it.
     public var hasFailed: Bool { return self.failureInfo != nil }
     /// Any contextual object that was supplied when unboxing was started
-    public let context: AnyObject?
+    public let context: Any?
     
-    private var failureInfo: (key: String, value: AnyObject?)?
+    private var failureInfo: (key: String, value: Any?)?
     private let dictionary: UnboxableDictionary
     
     // MARK: - Private initializer
     
-    private init(dictionary: UnboxableDictionary, context: AnyObject?) {
+    private init(dictionary: UnboxableDictionary, context: Any?) {
         self.dictionary = dictionary
         self.context = context
     }
@@ -363,7 +363,7 @@ public class Unboxer {
     }
     
     /// Make this Unboxer to fail for a certain key and invalid value. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
-    public func failForInvalidValue(invalidValue: AnyObject?, forKey key: String) {
+    public func failForInvalidValue(invalidValue: Any?, forKey key: String) {
         self.failureInfo = (key, invalidValue)
     }
     

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -459,20 +459,6 @@ public class Unboxer {
     public func failForInvalidValue(invalidValue: Any?, forKey key: String) {
         self.failureInfo = (key, invalidValue)
     }
-    
-    // MARK: - Private
-    
-    private func throwIfFailed() throws {
-        guard let failureInfo = self.failureInfo else {
-            return
-        }
-        
-        if let failedValue: Any = failureInfo.value {
-            throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
-        }
-        
-        throw UnboxError.MissingKey(failureInfo.key)
-    }
 }
 
 // MARK: - UnboxValueResolver
@@ -599,5 +585,19 @@ private extension Unboxable {
 private extension UnboxableWithContext {
     static func unboxFallbackValueWithContext(context: ContextType) -> Self {
         return self.init(unboxer: Unboxer(dictionary: [:], context: context), context: context)
+    }
+}
+
+private extension Unboxer {
+    func throwIfFailed() throws {
+        guard let failureInfo = self.failureInfo else {
+            return
+        }
+        
+        if let failedValue: Any = failureInfo.value {
+            throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
+        }
+        
+        throw UnboxError.MissingKey(failureInfo.key)
     }
 }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -422,6 +422,20 @@ public class Unboxer {
         })
     }
     
+    /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
+    public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> [T] {
+        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: true, valueTransform: {
+            return Unbox($0, context: context)
+        })
+    }
+    
+    /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
+    public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> [T]? {
+        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: false, valueTransform: {
+            return Unbox($0, context: context)
+        })
+    }
+    
     /// Unbox a required value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String) -> T {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -368,7 +368,7 @@ public class Unboxer {
     
     /// Unbox a required nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String) -> T {
-        return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: T(unboxer: self), transform: {
+        return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {
             return Unbox($0, context: self.context)
         })
     }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -383,28 +383,28 @@ public class Unboxer {
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: true, valueTransform: {
-            return Unbox($0)
+            return Unbox($0, context: self.context)
         })
     }
     
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: false, valueTransform: {
-            return Unbox($0)
+            return Unbox($0, context: self.context)
         })
     }
     
     /// Unbox a required Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [String : T] {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, required: true, valueTransform: {
-            return Unbox($0)
+            return Unbox($0, context: self.context)
         })
     }
     
     /// Unbox an optional Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [String : T]? {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, required: false, valueTransform: {
-            return Unbox($0)
+            return Unbox($0, context: self.context)
         })
     }
     

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -243,6 +243,8 @@ extension NSURL: UnboxableByTransform {
  *  An Unboxer may also be manually failed, by using the `failForKey()` or `failForInvalidValue(forKey:)` APIs.
  */
 public class Unboxer {
+    /// All keys contained within the underlying JSON data that is being unboxed
+    public var allKeys: [String] { return Array(self.dictionary.keys) }
     /// Whether the Unboxer has failed, and a `nil` value will be returned from the `Unbox()` function that triggered it.
     public var hasFailed: Bool { return self.failureInfo != nil }
     /// Any contextual object that was supplied when unboxing was started

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -176,6 +176,25 @@ class UnboxTests: XCTestCase {
             XCTFail()
         }
     }
+    
+    func testAllKeys() {
+        let dictionary = [
+            "a" : "A",
+            "b" : 12,
+            "c" : ["C"]
+        ]
+        
+        struct Model: Unboxable {
+            init(unboxer: Unboxer) {
+                XCTAssertEqual(unboxer.allKeys.count, 3)
+                XCTAssertTrue(unboxer.allKeys.contains("a"))
+                XCTAssertTrue(unboxer.allKeys.contains("b"))
+                XCTAssertTrue(unboxer.allKeys.contains("c"))
+            }
+        }
+        
+        Unbox(dictionary) as Model?
+    }
 }
 
 private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool) -> UnboxableDictionary {

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -203,6 +203,7 @@ private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool)
         UnboxTestMock.requiredIntKey : 15,
         UnboxTestMock.requiredDoubleKey : Double(1.5),
         UnboxTestMock.requiredFloatKey : Float(3.14),
+        UnboxTestMock.requiredEnumKey : 1,
         UnboxTestMock.requiredStringKey :  "hello",
         UnboxTestMock.requiredURLKey : "http://www.google.com",
         UnboxTestMock.requiredArrayKey : ["unbox", "is", "pretty", "cool", "right?"]
@@ -219,6 +220,15 @@ private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool)
 
 // MARK: - Mocks
 
+private enum UnboxTestEnum: Int, UnboxableEnum {
+    case First
+    case Second
+    
+    private static func unboxFallbackValue() -> UnboxTestEnum {
+        return .First
+    }
+}
+
 private class UnboxTestBaseMock: Unboxable {
     static let requiredBoolKey = "requiredBool"
     static let optionalBoolKey = "optionalBool"
@@ -228,6 +238,8 @@ private class UnboxTestBaseMock: Unboxable {
     static let optionalDoubleKey = "optionalDouble"
     static let requiredFloatKey = "requiredFloat"
     static let optionalFloatKey = "optionalFloat"
+    static let requiredEnumKey = "requiredEnum"
+    static let optionalEnumKey = "optionalEnum"
     static let requiredStringKey = "requiredString"
     static let optionalStringKey = "optionalString"
     static let requiredURLKey = "requiredURL"
@@ -243,6 +255,8 @@ private class UnboxTestBaseMock: Unboxable {
     let optionalDouble: Double?
     let requiredFloat: Float
     let optionalFloat: Float?
+    let requiredEnum: UnboxTestEnum
+    let optionalEnum: UnboxTestEnum?
     let requiredString: String
     let optionalString: String?
     let requiredURL: NSURL
@@ -259,6 +273,8 @@ private class UnboxTestBaseMock: Unboxable {
         self.optionalDouble = unboxer.unbox(UnboxTestBaseMock.optionalDoubleKey)
         self.requiredFloat = unboxer.unbox(UnboxTestBaseMock.requiredFloatKey)
         self.optionalFloat = unboxer.unbox(UnboxTestBaseMock.optionalFloatKey)
+        self.requiredEnum = unboxer.unbox(UnboxTestBaseMock.requiredEnumKey)
+        self.optionalEnum = unboxer.unbox(UnboxTestBaseMock.optionalEnumKey)
         self.requiredString = unboxer.unbox(UnboxTestBaseMock.requiredStringKey)
         self.optionalString = unboxer.unbox(UnboxTestBaseMock.optionalStringKey)
         self.requiredURL = unboxer.unbox(UnboxTestBaseMock.requiredURLKey)
@@ -288,6 +304,10 @@ private class UnboxTestBaseMock: Unboxable {
                 verificationOutcome = self.verifyPropertyValue(self.requiredFloat, againstDictionaryValue: value)
             case UnboxTestBaseMock.optionalFloatKey:
                 verificationOutcome = self.verifyPropertyValue(self.optionalFloat, againstDictionaryValue: value)
+            case UnboxTestBaseMock.requiredEnumKey:
+                verificationOutcome = self.verifyEnumPropertyValue(self.requiredEnum, againstDictionaryValue: value)
+            case UnboxTestBaseMock.optionalEnumKey:
+                verificationOutcome = self.verifyEnumPropertyValue(self.optionalEnum, againstDictionaryValue: value)
             case UnboxTestBaseMock.requiredStringKey:
                 verificationOutcome = self.verifyPropertyValue(self.requiredString, againstDictionaryValue: value)
             case UnboxTestBaseMock.optionalStringKey:
@@ -312,6 +332,16 @@ private class UnboxTestBaseMock: Unboxable {
         if let propertyValue = propertyValue {
             if let typedDictionaryValue = dictionaryValue as? T {
                 return propertyValue == typedDictionaryValue
+            }
+        }
+        
+        return false
+    }
+    
+    func verifyEnumPropertyValue<T: UnboxableEnum where T: Equatable>(propertyValue: T?, againstDictionaryValue dictionaryValue: AnyObject?) -> Bool {
+        if let rawValue = dictionaryValue as? T.RawValue {
+            if let enumValue = T(rawValue: rawValue) {
+                return propertyValue == enumValue
             }
         }
         


### PR DESCRIPTION
Unbox 1.1 is here! Review it before it's released. Any comments and feedback are very welcome :)

### Changes in 1.1:

#### Potentially breaking changes for users of Unbox 1.0

**`Any` instead of `AnyObject` in context & manual fail APIs**
Enables structs to be used as contextual objects, and when manually failing an unboxing process.

**`fallbackValue` renamed to `unboxFallbackValue`**
To avoid conflicting with other methods when confirming to an Unbox protocol.

**`UnboxTransformer` removed in favor of static transformation functions on `UnboxableByTransform`**
Enables transformations to be written directly on the type that is to be transformed, reducing the amount of code and decreasing complexity.

**`Unboxer.requiredContextWithFallbackValue()` has been removed**
A new `UnboxableWithContext` protocol has been introduced for types that require a contextual object to be unboxed, moving this check to compile time instead of rutime, rendering this method obsolete.

#### Other changes

**Unbox `enum` values directly**
You no longer have to implement your own `enum` value decoding. Make your `enum` types conform to `UnboxableEnum` and then just unbox the values as normal:

```swift
enum MyEnum: Int, UnboxableEnum {
   case First
   case Second

   static func unboxFallbackValue() {
      return .First
   }
}

struct MyModel: Unboxable {
   let myEnum: MyEnum

   init(unboxer: Unboxer) {
      self.myEnum = unboxer.unbox("myEnum")
   }
}
```

**Allow types to require a contextual object to be unboxed using `UnboxableWithContext`**
This new protocol has another initializer (`init(unboxer: Unboxer, context: Self.ContextType)`) than the default `Unboxable` protocol, and requires a contextual object of a certain type to be passed into the unboxing process. This is super useful for managing dependencies between different models, or to pass some form of state into the unboxing process.

**Access all keys of the underlying dictionary that's being unboxed**
Now available through `Unboxer.allKeys`. Useful for iterations, checking if a key exists, etc.

*Included are also misc documentation fixes.*