### PR TITLE
Unbox 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ struct UniqueIdentifier: UnboxableByTransform {
 }
 ```
 
+### Array support
+
+If the JSON you want to unbox comes in the format of a root `Array`, you can also easily unbox it into an array of models in one go using the exact same `Unbox()` API.
+
 ### Built-in enum support
 
 You can also unbox `enums` directly, without having to handle the case if they failed to initialize. All you have to do is make any `enum` type you wish to unbox conform to `UnboxableEnum`, like this:

--- a/Unbox.podspec
+++ b/Unbox.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Unbox"
-  s.version      = "1.1"
+  s.version      = "1.2"
   s.summary      = "The easy to use Swift JSON decoder."
   s.description  = <<-DESC
     Unbox is an easy to use Swift JSON decoder. Don't spend hours writing JSON decoding code - just unbox it instead!
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
-  s.source       = { :git => "https://github.com/JohnSundell/Unbox.git", :tag => "1.1" }
+  s.source       = { :git => "https://github.com/JohnSundell/Unbox.git", :tag => "1.2" }
   s.source_files  = "Unbox.swift"
   s.framework  = "Foundation"
 end

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -328,14 +328,14 @@ public class Unboxer {
     
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [T] {
-        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: true, valueTransform: {
+        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, fallbackValue: [], transform: {
             return Unbox($0, context: self.context)
         })
     }
     
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [T]? {
-        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: false, valueTransform: {
+        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, transform: {
             return Unbox($0, context: self.context)
         })
     }
@@ -370,14 +370,14 @@ public class Unboxer {
     
     /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> [T] {
-        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: true, valueTransform: {
+        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, fallbackValue: [], transform: {
             return Unbox($0, context: context)
         })
     }
     
     /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> [T]? {
-        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveCollectionValuesForKey(key, required: false, valueTransform: {
+        return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, transform: {
             return Unbox($0, context: context)
         })
     }
@@ -464,29 +464,6 @@ private class UnboxValueResolver<T> {
         }
         
         return nil
-    }
-}
-
-extension UnboxValueResolver where T: CollectionType {
-    func resolveCollectionValuesForKey<R>(key: String, required: Bool, valueTransform: T.Generator.Element -> R?) -> [R] {
-        if let unboxedArray = self.resolveOptionalValueForKey(key) {
-            var transformedArray = [R]()
-            
-            for unboxedValue in unboxedArray {
-                if let transformed = valueTransform(unboxedValue) {
-                    transformedArray.append(transformed)
-                } else if required {
-                    self.unboxer.failForInvalidValue(unboxedValue, forKey: key)
-                    return []
-                }
-            }
-            
-            return transformedArray
-        } else if required {
-            self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
-        }
-        
-        return []
     }
 }
 

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -553,11 +553,15 @@ private extension UnboxableWithContext {
 
 private extension Unboxer {
     static func unboxerFromData(data: NSData, context: Any?) throws -> Unboxer {
-        guard let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary else {
+        do {
+            guard let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary else {
+                throw UnboxError.InvalidData
+            }
+            
+            return Unboxer(dictionary: dictionary, context: context)
+        } catch {
             throw UnboxError.InvalidData
         }
-        
-        return Unboxer(dictionary: dictionary, context: context)
     }
     
     func performUnboxing<T: Unboxable>() throws -> T {

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -32,110 +32,94 @@ public typealias UnboxableDictionary = [String : AnyObject]
 
 // MARK: - Main Unbox functions
 
-/**
- *  Unbox (decode) a dictionary into a model
- *
- *  @param dictionary The dictionary to decode. Must be a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
- *
- *  @discussion This function gets its return type from the context in which it's called.
- *  If the context is ambigious, you need to supply it, like:
- *
- *  `let unboxed: MyUnboxable? = Unbox(dictionary)`
- *
- *  @return A model of type `T` or `nil` if an error was occured. If you prefer do, try, catch
- *  error handling instead of optionals; use `UnboxOrThrow` instead.
- */
+/// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
     return try? UnboxOrThrow(dictionary, context: context)
 }
 
-/**
- *  Unbox (decode) a set of data into a model
- *
- *  @param data The data to decode. Must be convertible into a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
- *
- *  @discussion See the documentation for the main `Unbox(dictionary:)` function above for more information.
- */
+/// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object
+public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) -> [T]? {
+    return try? UnboxOrThrow(dictionaries, context: context)
+}
+
+/// Unbox binary data into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
     return try? UnboxOrThrow(data, context: context)
 }
 
-/**
- *  Unbox (decode) a dictionary into a model using a context
- *
- *  @param dictionary The dictionary to decode. Must be a valid JSON dictionary.
- *  @param context The contextual object to use during unboxing.
- *
- *  @discussion See the documentation for `Unbox(dictionary:)` for more information.
- */
+/// Unbox binary data into an array of `T`, while optionally using a contextual object
+public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> [T]? {
+    return try? UnboxOrThrow(data, context: context)
+}
+
+/// Unbox a JSON dictionary into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
     return try? UnboxOrThrow(dictionary, context: context)
 }
 
-/**
- *  Unbox (decode) a set of data into a model using a context
- *
- *  @param data The data to decode. Must be convertible into a valid JSON dictionary.
- *  @param context The contextual object to use during unboxing.
- *
- *  @discussion See the documentation for `Unbox(data:)` for more information.
- */
+/// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object
+public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) -> [T]? {
+    return try? UnboxOrThrow(dictionaries, context: context)
+}
+
+/// Unbox binary data into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
     return try? UnboxOrThrow(data, context: context)
 }
 
-// MARK: - Unbox functions with error handling
+/// Unbox binary data into an array of `T`, while using a required contextual object
+public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> [T]? {
+    return try? UnboxOrThrow(data, context: context)
+}
 
-/**
- *  Unbox (decode) a dictionary into a model, or throw an UnboxError if the operation failed
- *
- *  @param dictionary The dictionary to decode. Must be a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
- *
- *  @discussion This function throws an UnboxError if the supplied dictionary couldn't be decoded
- *  for any reason. See the documentation for the main Unbox() function above for more information.
- */
+// MARK: - Throwing Unbox functions
+
+/// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
     return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
 }
 
-/**
- *  Unbox (decode) a set of data into a model, or throw an UnboxError if the operation failed
- *
- *  @param data The data to decode. Must be convertible into a valid JSON dictionary.
- *  @param context Any contextual object that should be available during unboxing.
- *
- *  @discussion This function throws an UnboxError if the supplied data couldn't be decoded for
- *  any reason. See the documentation for the main Unbox() function above for more information.
- */
+/// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
+public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
+    return try dictionaries.map({
+        try UnboxOrThrow($0, context: context)
+    })
+}
+
+/// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
     return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
 }
 
-/**
- *  Unbox (decode) a dictionary into a model using a context, or throw an UnboxError if the operation failed
- *
- *  @param dictionary The dictionary to decode. Must be a valid JSON dictionary.
- *  @param context The contextual object to use during unboxing.
- *
- *  @discussion See the documentation for `UnboxOrThrow(dictionary:)` for more information.
- */
+/// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
+public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
+    return try Unboxer.unboxersFromData(data, context: context).map({
+        return try $0.performUnboxing()
+    })
+}
+
+/// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
     return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
 }
 
-/**
- *  Unbox (decode) a set of data into a model using a context, or throw an UnboxError if the operation failed
- *
- *  @param data The data to decode. Must be convertible into a valid JSON dictionary.
- *  @param context The contextual object to use during unboxing.
- *
- *  @discussion See the documentation for `UnboxOrThrow(data:)` for more information.
- */
+/// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
+public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
+    return try dictionaries.map({
+        try UnboxOrThrow($0, context: context)
+    })
+}
+
+/// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
     return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+}
+
+/// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
+public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
+    return try Unboxer.unboxersFromData(data, context: context).map({
+        return try $0.performUnboxingWithContext(context)
+    })
 }
 
 // MARK: - Error type
@@ -559,6 +543,20 @@ private extension Unboxer {
             }
             
             return Unboxer(dictionary: dictionary, context: context)
+        } catch {
+            throw UnboxError.InvalidData
+        }
+    }
+    
+    static func unboxersFromData(data: NSData, context: Any?) throws -> [Unboxer] {
+        do {
+            guard let array = try NSJSONSerialization.JSONObjectWithData(data, options: [.AllowFragments]) as? [UnboxableDictionary] else {
+                throw UnboxError.InvalidData
+            }
+            
+            return array.map({
+                return Unboxer(dictionary: $0, context: context)
+            })
         } catch {
             throw UnboxError.InvalidData
         }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -150,8 +150,8 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
             return baseDescription + "Missing key (\(key))"
         case .InvalidValue(let key, let valueDescription):
             return baseDescription + "Invalid value (\(valueDescription)) for key (\(key))"
-        case .InvalidDictionary:
-            return "Invalid dictionary"
+        case .InvalidData:
+            return "Invalid data"
         }
     }
     
@@ -160,8 +160,8 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
     /// Thrown when a required key contained an invalid value in an unboxed dictionary. Contains the invalid
     /// key and a description of the invalid data.
     case InvalidValue(String, String)
-    /// Thrown when an unboxed dictionary was either missing or contained invalid data
-    case InvalidDictionary
+    /// Thrown when a piece of data (NSData) could not be unboxed because it was considered invalid
+    case InvalidData
 }
 
 // MARK: - Protocols
@@ -554,7 +554,7 @@ private extension UnboxableWithContext {
 private extension Unboxer {
     static func unboxerFromData(data: NSData, context: Any?) throws -> Unboxer {
         guard let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary else {
-            throw UnboxError.InvalidDictionary
+            throw UnboxError.InvalidData
         }
         
         return Unboxer(dictionary: dictionary, context: context)

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -84,7 +84,7 @@ class UnboxTests: XCTestCase {
             invalidDictionary.removeValueForKey(key)
             
             do {
-                let _: UnboxTestMock = try UnboxOrThrow(invalidDictionary)
+                try UnboxOrThrow(invalidDictionary) as UnboxTestMock
                 XCTFail("Unbox should have thrown for a missing value")
             } catch UnboxError.MissingKey(key) {
                 // Test passed
@@ -104,7 +104,7 @@ class UnboxTests: XCTestCase {
             invalidDictionary[key] = invalidValue
             
             do {
-                let _: UnboxTestMock = try UnboxOrThrow(invalidDictionary)
+                try UnboxOrThrow(invalidDictionary) as UnboxTestMock
                 XCTFail("Unbox should have thrown for an invalid value")
             } catch UnboxError.InvalidValue(key, invalidValueDescription) {
                 // Test passed
@@ -120,7 +120,7 @@ class UnboxTests: XCTestCase {
     func testThrowingForInvalidData() {
         if let data = "Not a dictionary".dataUsingEncoding(NSUTF8StringEncoding) {
             do {
-                let _: UnboxTestMock = try UnboxOrThrow(data)
+                try UnboxOrThrow(data) as UnboxTestMock
                 XCTFail("Unbox should have thrown for invalid data")
             } catch UnboxError.InvalidData {
                 // Test passed

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -122,8 +122,10 @@ class UnboxTests: XCTestCase {
             do {
                 let _: UnboxTestMock = try UnboxOrThrow(data)
                 XCTFail("Unbox should have thrown for invalid data")
-            } catch {
+            } catch UnboxError.InvalidData {
                 // Test passed
+            } catch {
+                XCTFail("Unbox did not return the correct error type")
             }
         } else {
             XCTFail("Could not create data from a string")

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -76,6 +76,24 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testUnboxingArrayOfDictionaries() {
+        let dictionaries = [
+            UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false),
+            UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false),
+            UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
+        ]
+        
+        guard let unboxedArray: [UnboxTestMock] = Unbox(dictionaries) else {
+            return XCTFail()
+        }
+        
+        XCTAssertEqual(unboxedArray.count, 3)
+        
+        for unboxed in unboxedArray {
+            unboxed.verifyAgainstDictionary(UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false))
+        }
+    }
+    
     func testThrowingForMissingRequiredValues() {
         let validDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
         
@@ -129,6 +147,38 @@ class UnboxTests: XCTestCase {
             }
         } else {
             XCTFail("Could not create data from a string")
+        }
+    }
+    
+    func testThrowingForInvalidDataArray() {
+        let notDictionaryArray = [12, 13, 9]
+        
+        guard let data = try? NSJSONSerialization.dataWithJSONObject(notDictionaryArray, options: []) else {
+            return XCTFail()
+        }
+        
+        do {
+            try UnboxOrThrow(data) as UnboxTestMock
+            XCTFail()
+        } catch UnboxError.InvalidData {
+            // Test passed
+        } catch {
+            XCTFail("Unbox did not return the correct error type")
+        }
+    }
+    
+    func testThrowingForSingleInvalidDictionaryInArray() {
+        let dictionaries = [
+            UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false),
+            ["invalid" : "dictionary"],
+            UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
+        ]
+        
+        do {
+            try UnboxOrThrow(dictionaries) as [UnboxTestMock]
+            XCTFail()
+        } catch {
+            // Test passed
         }
     }
     


### PR DESCRIPTION
The next version of Unbox - `1.2` - implements the most requested feature so far: being able to unbox JSON that has an `Array` as its root object. While nested arrays have been supported for a long time, support for root Arrays has been added to all variants of the main `Unbox` API.

With this new support the following is possible:

```swift
let dataWithRootArray: NSData
let modelArray: [MyModel]? = Unbox(dataWithRootArray)
```

As part of this, `UnboxError.InvalidDictionary` has been renamed to `UnboxError.InvalidData`, which is the only breaking change from `1.1`.

Resolves https://github.com/JohnSundell/Unbox/issues/11