### PR TITLE
exposes Unboxer's underlying dictionary.

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -311,7 +311,7 @@ public class Unboxer {
     public let context: Any?
     
     private var failureInfo: (key: String, value: Any?)?
-    private let dictionary: UnboxableDictionary
+    public let dictionary: UnboxableDictionary
     
     // MARK: - Private initializer
     


### PR DESCRIPTION
It's already a `let` constant so it can't be changed. Exposing it allows for a user unboxing it to look at the underlying data to make choices, if necessary, on how to proceed.

For example, in my use case I have an API that returns top level object in 1 format with, but also, in the same response, references to those objects in a slightly more compact format:

```json
[
    {
        "doc": {
            "obj_id": "12345",
            "label": "Lorem Ipsum"
        },
        "meta": {
            "type": "history.object",
            "timestamp": "123567567"
        }
    },
    {
        "doc": {
            "obj_id": "67890",
            "objects": [
                {"obj_id": "12345", "label": "Lorem Ipsum"}
            ]
        },
        "meta": {
            "type": "history.collection",
            "timestamp": "12312123"
        }
    }
]
```

the `objects` array in the `history.collection` doesn't contain the `doc` or `meta` keys. With the dictionary exposed publically I can just check during unpacking if I have a `doc` key or not and set my unboxing prefix accordingly:

```swift
        var prefix = ""

        if let _ = unboxer.dictionary["doc"]{
            prefix = "doc."
        }

        objId = unboxer.unbox("\(prefix)obj_id")
        label = unboxer.unbox("\(prefix)label")
```

Again, the dictionary is already constant so there is no threat of unexpected mutation, but it would allow for more robust conditional checking.