### PR TITLE
exposes Unboxer's init publically

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -129,7 +129,7 @@ public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.Conte
 public enum UnboxError: ErrorType, CustomStringConvertible {
     public var description: String {
         let baseDescription = "[Unbox error] "
-        
+
         switch self {
         case .MissingKey(let key):
             return baseDescription + "Missing key (\(key))"
@@ -141,7 +141,7 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
             return "A custom unboxing closure returned nil"
         }
     }
-    
+
     /// Thrown when a required key was missing in an unboxed dictionary. Contains the missing key.
     case MissingKey(String)
     /// Thrown when a required key contained an invalid value in an unboxed dictionary. Contains the invalid
@@ -165,7 +165,7 @@ public protocol Unboxable {
 public protocol UnboxableWithContext {
     /// The type of the contextual object that this model requires when unboxed
     typealias ContextType
-    
+
     /// Initialize an instance of this model by unboxing a dictionary & using a context
     init(unboxer: Unboxer, context: ContextType)
 }
@@ -192,7 +192,7 @@ public protocol UnboxableKey: Hashable, UnboxCompatibleType {
 public protocol UnboxableByTransform: UnboxCompatibleType {
     /// The type of raw value that this type can be transformed from
     typealias UnboxRawValueType: UnboxableRawType
-    
+
     /// Attempt to transform a raw unboxed value into an instance of this type
     static func transformUnboxedValue(unboxedValue: UnboxRawValueType) -> Self?
 }
@@ -209,7 +209,7 @@ public protocol UnboxFormatter {
     typealias UnboxRawValueType: UnboxableRawType
     /// The type of value that this formatter produces as output
     typealias UnboxFormattedType
-    
+
     /// Format an unboxed value into another value (or nil if the formatting failed)
     func formatUnboxedValue(unboxedValue: UnboxRawValueType) -> UnboxFormattedType?
 }
@@ -261,11 +261,11 @@ extension String: UnboxableRawType {
 /// Extension making NSURL Unboxable by transform
 extension NSURL: UnboxableByTransform {
     public typealias UnboxRawValueType = String
-    
+
     public static func transformUnboxedValue(rawValue: String) -> Self? {
         return self.init(string: rawValue)
     }
-    
+
     public static func unboxFallbackValue() -> Self {
         return self.init()
     }
@@ -281,7 +281,7 @@ extension String: UnboxableKey {
 /// Extension making NSDate unboxable with an NSDateFormatter
 extension NSDate: UnboxableWithFormatter {
     public typealias UnboxFormatterType = NSDateFormatter
-    
+
     public static func unboxFallbackValue() -> Self {
         return self.init()
     }
@@ -313,209 +313,209 @@ public class Unboxer {
     public var hasFailed: Bool { return self.failureInfo != nil }
     /// Any contextual object that was supplied when unboxing was started
     public let context: Any?
-    
+
     private var failureInfo: (key: String, value: Any?)?
-    
-    // MARK: - Private initializer
-    
-    private init(dictionary: UnboxableDictionary, context: Any?) {
+
+    // MARK: - Public initializer
+
+    public init(dictionary: UnboxableDictionary, context: Any?) {
         self.dictionary = dictionary
         self.context = context
     }
-    
+
     // MARK: - Custom unboxing API
-    
+
     /// Perform custom unboxing using an Unboxer (created from a dictionary) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithDictionary<T>(dictionary: UnboxableDictionary, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
         return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure)
     }
-    
+
     /// Perform custom unboxing using an Unboxer (created from NSData) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithData<T>(data: NSData, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
         return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure)
     }
-    
+
     // MARK: - Value accessing API
-    
+
     /// Unbox a required raw type
     public func unbox<T: UnboxableRawType>(key: String) -> T {
         return UnboxValueResolver<T>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue())
     }
-    
+
     /// Unbox an optional raw type
     public func unbox<T: UnboxableRawType>(key: String) -> T? {
         return UnboxValueResolver<T>(self).resolveOptionalValueForKey(key)
     }
-    
+
     /// Unbox a required Array of raw values
     public func unbox<T where T: UnboxableRawType>(key: String) -> [T] {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, fallbackValue: [])
     }
-    
+
     /// Unbox an optional Array of raw values
     public func unbox<T where T: UnboxableRawType>(key: String) -> [T]? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key)
     }
-    
+
     /// Unbox a required raw value from a certain index in a nested Array
     public func unbox<T where T: UnboxableRawType>(key: String, index: Int) -> T {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {
             if index < 0 || index >= $0.count {
                 return nil
             }
-            
+
             return $0[index]
         })
     }
-    
+
     /// Unbox an optional raw value from a certain index in a nested Array
     public func unbox<T where T: UnboxableRawType>(key: String, index: Int) -> T? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key, transform: {
             if index < 0 || index >= $0.count {
                 return nil
             }
-            
+
             return $0[index]
         })
     }
-    
+
     /// Unbox a required Dictionary with untyped values, without applying a transform on them
     public func unbox<K: UnboxableKey>(key: String) -> [K : AnyObject] {
         return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, required: true, valueTransform: { $0 }) ?? [:]
     }
-    
+
     /// Unbox an optional Dictionary with untyped values, without applying a transform on them
     public func unbox<K: UnboxableKey>(key: String) -> [K : AnyObject]? {
         return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, required: false, valueTransform: { $0 })
     }
-    
+
     /// Unbox a required Dictionary with raw values
     public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String) -> [K : V] {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, required: true, valueTransform: { $0 }) ?? [:]
     }
-    
+
     /// Unbox an optional Dictionary with raw values
     public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String) -> [K : V]? {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, required: false, valueTransform: { $0 })
     }
-    
+
     /// Unbox a required enum value
     public func unbox<T: UnboxableEnum>(key: String) -> T {
         return UnboxValueResolver<T.RawValue>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {
             return T(rawValue: $0)
         })
     }
-    
+
     /// Unbox an optional enum value
     public func unbox<T: UnboxableEnum>(key: String) -> T? {
         return UnboxValueResolver<T.RawValue>(self).resolveOptionalValueForKey(key, transform: {
             return T(rawValue: $0)
         })
     }
-    
+
     /// Unbox a required nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String) -> T {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox an optional nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String) -> T? {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, fallbackValue: [], transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox a required Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
     public func unbox<K: UnboxableKey, V: Unboxable>(key: String) -> [K : V] {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, required: true, valueTransform: {
             return Unbox($0, context: self.context)
         }) ?? [:]
     }
-    
+
     /// Unbox an optional Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
     public func unbox<K: UnboxableKey, V: Unboxable>(key: String) -> [K : V]? {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, required: false, valueTransform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox a required nested UnboxableWithContext type
     public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> T {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValueWithContext(context), transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox an optional nested UnboxableWithContext type
     public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> T? {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, fallbackValue: [], transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, context: T.ContextType) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox a required value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String) -> T {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {
             return T.transformUnboxedValue($0)
         })
     }
-    
+
     /// Unbox an optional value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String) -> T? {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveOptionalValueForKey(key, transform: {
             return T.transformUnboxedValue($0)
         })
     }
-    
+
     /// Unbox a required value that can be formatted using a formatter
     public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, formatter: F) -> T {
         return UnboxValueResolver<F.UnboxRawValueType>(self).resolveRequiredValueForKey(key, fallbackValue: T.unboxFallbackValue(), transform: {
             return formatter.formatUnboxedValue($0)
         })
     }
-    
+
     /// Unbox an optional value that can be formatted using a formatter
     public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, formatter: F) -> T? {
         return UnboxValueResolver<F.UnboxRawValueType>(self).resolveOptionalValueForKey(key, transform: {
             return formatter.formatUnboxedValue($0)
         })
     }
-    
+
     /// Make this Unboxer fail for a certain key. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForKey(key: String) {
         self.failForInvalidValue(nil, forKey: key)
     }
-    
+
     /// Make this Unboxer fail for a certain key and invalid value. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForInvalidValue(invalidValue: Any?, forKey key: String) {
         self.failureInfo = (key, invalidValue)
@@ -526,42 +526,42 @@ public class Unboxer {
 
 private class UnboxValueResolver<T> {
     let unboxer: Unboxer
-    
+
     init(_ unboxer: Unboxer) {
         self.unboxer = unboxer
     }
-    
+
     func resolveRequiredValueForKey(key: String, @autoclosure fallbackValue: () -> T) -> T {
         return self.resolveRequiredValueForKey(key, fallbackValue: fallbackValue, transform: {
             return $0
         })
     }
-    
+
     func resolveRequiredValueForKey<R>(key: String, @autoclosure fallbackValue: () -> R, transform: T -> R?) -> R {
         if let value = self.resolveOptionalValueForKey(key, transform: transform) {
             return value
         }
-        
+
         self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
-        
+
         return fallbackValue()
     }
-    
+
     func resolveOptionalValueForKey(key: String) -> T? {
         return self.resolveOptionalValueForKey(key, transform: {
             return $0
         })
     }
-    
+
     func resolveOptionalValueForKey<R>(var key: String, transform: T -> R?) -> R? {
         var dictionary = self.unboxer.dictionary
-        
+
         if key.containsString(".") {
             let components = key.componentsSeparatedByString(".")
-            
+
             for var i = 0; i < components.count; i++ {
                 let keyPathComponent = components[i]
-                
+
                 if i == components.count - 1 {
                     key = keyPathComponent
                 } else if let nestedDictionary = dictionary[keyPathComponent] as? UnboxableDictionary {
@@ -577,7 +577,7 @@ private class UnboxValueResolver<T> {
                 return transformed
             }
         }
-        
+
         return nil
     }
 }
@@ -586,24 +586,24 @@ extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConver
     func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, required: Bool, valueTransform: T.Value -> V?) -> [K : V]? {
         if let unboxedDictionary = self.resolveOptionalValueForKey(key) {
             var transformedDictionary = [K : V]()
-            
+
             for (unboxedKey, unboxedValue) in unboxedDictionary {
                 guard let transformedKey = K.transformUnboxedKey(unboxedKey), transformedValue = valueTransform(unboxedValue) else {
                     if required {
                         self.unboxer.failForInvalidValue(unboxedDictionary, forKey: key)
                     }
-                    
+
                     return nil
                 }
-                
+
                 transformedDictionary[transformedKey] = transformedValue
             }
-            
+
             return transformedDictionary
         } else if required {
             self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
         }
-        
+
         return [:]
     }
 }
@@ -628,19 +628,19 @@ private extension Unboxer {
             guard let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary else {
                 throw UnboxError.InvalidData
             }
-            
+
             return Unboxer(dictionary: dictionary, context: context)
         } catch {
             throw UnboxError.InvalidData
         }
     }
-    
+
     static func unboxersFromData(data: NSData, context: Any?) throws -> [Unboxer] {
         do {
             guard let array = try NSJSONSerialization.JSONObjectWithData(data, options: [.AllowFragments]) as? [UnboxableDictionary] else {
                 throw UnboxError.InvalidData
             }
-            
+
             return array.map({
                 return Unboxer(dictionary: $0, context: context)
             })
@@ -648,38 +648,38 @@ private extension Unboxer {
             throw UnboxError.InvalidData
         }
     }
-    
+
     func performUnboxing<T: Unboxable>() throws -> T {
         let unboxed = T(unboxer: self)
         try self.throwIfFailed()
         return unboxed
     }
-    
+
     func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType) throws -> T {
         let unboxed = T(unboxer: self, context: context)
         try self.throwIfFailed()
         return unboxed
     }
-    
+
     func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?) throws -> T {
         guard let unboxed: T = closure(self) else {
             throw UnboxError.CustomUnboxingFailed
         }
-        
+
         try self.throwIfFailed()
-        
+
         return unboxed
     }
-    
+
     func throwIfFailed() throws {
         guard let failureInfo = self.failureInfo else {
             return
         }
-        
+
         if let failedValue: Any = failureInfo.value {
             throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
         }
-        
+
         throw UnboxError.MissingKey(failureInfo.key)
     }
 }


### PR DESCRIPTION
My use case is that I need to go `to <-> from JSON`. Unboxer get's me from JSON wonderfully. I love it, I'd marry it.  

During the `to` JSON part, however, I have to start filling up my model with more functionality which saddens me. 

Personal preference, I like to keep my models really dumb. So I said, "hey! I know, I'll just pull all the `to <-> from` out of the model into a service that does the work and just initialize `Unboxer` for all it's swanky `unbox<T>` functionality." "Alas" I said, the initializer on `Unboxer` is private =( It doesn't have to be though! So I tried it out, maybe things blow up and I just don't know it.

Turns out, nothing blows up, and it appears as though convenience and flexibility rain from on high.

Here's an example of one of my serializer classes using this change:

```swift
public struct ActivitySerializer {

    public static func serialize(model: Activity) -> AnyObject{
        var data = [String: AnyObject]()

        data["obj_id"] = model.objId
        data["label"] = model.label

        return data
    }

    public static func deserialize(value: AnyObject) -> Activity? {
        guard let json = value as? [String: AnyObject] else {
            return nil
        }

        let unboxer = Unboxer(dictionary: json, context: nil) // Weather forecast: 100% chance of AWESOME!

        let model = Activity(
            objId: unboxer.unbox("obj_id"), // awe SNAP!
            label: unboxer.unbox("label") // awe SNAP again!
        )
        return model
    }
}
```

It's great! I don't even have to have my models extend `Unboxable`. I mean I can if I want, but for this particular case, I get to keep the knowledge away from my model all together and I love `Unbox` even more!

