### PR TITLE
Skip invalid data instead of exiting completely.

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -318,56 +318,6 @@ public class Unboxer {
         self.allowInvalidElements = allowInvalidElements
     }
     
-    // MARK: - Private unboxing
-
-    /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxing()
-    }
-
-    /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithDictionary<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-        return allowInvalidElements
-            ? dictionaries.flatMap { try? performUnboxingWithDictionary($0, context: context) }
-            : try dictionaries.map { try performUnboxingWithDictionary($0, context: context) }
-    }
-
-    /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
-    }
-
-    /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
-            return try $0.performUnboxing()
-        }
-    }
-
-    /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxingWithContext(context)
-    }
-
-    /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-        return allowInvalidElements
-            ? dictionaries.flatMap { try? UnboxOrThrow($0, context: context) }
-            : try dictionaries.map { try UnboxOrThrow($0, context: context) }
-    }
-
-    /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
-    }
-
-    /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
-    private static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
-            return try $0.performUnboxingWithContext(context)
-        }
-    }
-    
     // MARK: - Custom unboxing API
     
     /// Perform custom unboxing using an Unboxer (created from a dictionary) passed to a closure, or throw an UnboxError
@@ -740,6 +690,54 @@ private extension Unboxer {
         try self.throwIfFailed()
         
         return unboxed
+    }
+
+    /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
+    static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxing()
+    }
+
+    /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
+    static func performUnboxingWithDictionary<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return allowInvalidElements
+            ? dictionaries.flatMap { try? performUnboxingWithDictionary($0, context: context) }
+            : try dictionaries.map { try performUnboxingWithDictionary($0, context: context) }
+    }
+
+    /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    }
+
+    /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
+            return try $0.performUnboxing()
+        }
+    }
+
+    /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
+    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxingWithContext(context)
+    }
+
+    /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
+    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return allowInvalidElements
+            ? dictionaries.flatMap { try? UnboxOrThrow($0, context: context) }
+            : try dictionaries.map { try UnboxOrThrow($0, context: context) }
+    }
+
+    /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    }
+
+    /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
+            return try $0.performUnboxingWithContext(context)
+        }
     }
     
     func throwIfFailed() throws {

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -40,7 +40,7 @@ public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? =
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return try? Unboxer.performUnboxingWithDictionary(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDictionaries(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object
@@ -60,7 +60,7 @@ public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, cont
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return try? Unboxer.performUnboxingWithDictionaryAndContext(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object
@@ -82,7 +82,7 @@ public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context:
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
-    return try Unboxer.performUnboxingWithDictionary(dictionaries, context: context)
+    return try Unboxer.performUnboxingWithDictionaries(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
@@ -102,7 +102,7 @@ public func UnboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionar
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
-    return try Unboxer.performUnboxingWithDictionaryAndContext(dictionaries, context: context)
+    return try Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
@@ -674,7 +674,7 @@ private extension Unboxer {
         return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: allowInvalidElements).performUnboxing()
     }
 
-    static func performUnboxingWithDictionary<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+    static func performUnboxingWithDictionaries<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
         if allowInvalidElements {
             return dictionaries.flatMap {
                 try? performUnboxingWithDictionary($0, context: context, allowInvalidElements: allowInvalidElements)
@@ -700,7 +700,7 @@ private extension Unboxer {
         return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: allowInvalidElements).performUnboxingWithContext(context)
     }
 
-    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+    static func performUnboxingWithDictionariesAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
         if allowInvalidElements {
             return dictionaries.flatMap {
                 try? performUnboxingWithDictionaryAndContext($0, context: context, allowInvalidElements: allowInvalidElements)

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -319,7 +319,7 @@ public class Unboxer {
     
     /// Perform custom unboxing using an Unboxer (created from a dictionary) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithDictionary<T>(dictionary: UnboxableDictionary, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(false, closure: closure)
+        return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure, allowInvalidElements: false)
     }
     
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, or throw an UnboxError
@@ -336,7 +336,7 @@ public class Unboxer {
     
     /// Perform custom unboxing using an Unboxer (created from NSData) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithData<T>(data: NSData, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(false, closure: closure)
+        return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure, allowInvalidElements: false)
     }
     
     // MARK: - Value accessing API
@@ -719,7 +719,7 @@ private extension Unboxer {
         return unboxed
     }
     
-    func performCustomUnboxingWithClosure<T>(allowInvalidElements: Bool, closure: Unboxer -> T?) throws -> T {
+    func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?, allowInvalidElements: Bool) throws -> T {
         guard let unboxed: T = closure(self) else {
             throw UnboxError.CustomUnboxingFailed
         }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -35,92 +35,84 @@ public typealias UnboxableDictionary = [String : AnyObject]
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
-    return try? UnboxOrThrow(dictionary, context: context)
+    return try? Unboxer.performUnboxingWithDictionary(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return try? UnboxOrThrow(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDictionary(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
-    return try? UnboxOrThrow(data, context: context)
+    return try? Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return try? UnboxOrThrow(data, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithData(data, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
-    return try? UnboxOrThrow(dictionary, context: context)
+    return try? Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return try? UnboxOrThrow(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDictionaryAndContext(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
-    return try? UnboxOrThrow(data, context: context)
+    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return try? UnboxOrThrow(data, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 // MARK: - Throwing Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-    return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxing()
+    return try Unboxer.performUnboxingWithDictionary(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
-public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-    return allowInvalidElements
-        ? dictionaries.flatMap { try? UnboxOrThrow($0, context: context) }
-        : try dictionaries.map { try UnboxOrThrow($0, context: context) }
+public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
+    return try Unboxer.performUnboxingWithDictionary(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-    return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    return try Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
-public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-    return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map({
-        return try $0.performUnboxing()
-    })
+public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
+    return try Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-    return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxingWithContext(context)
+    return try Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
-public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-    return allowInvalidElements
-        ? dictionaries.flatMap { try? UnboxOrThrow($0, context: context) }
-        : try dictionaries.map { try UnboxOrThrow($0, context: context) }
+public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
+    return try Unboxer.performUnboxingWithDictionaryAndContext(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-    return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
-public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-    return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map({
-        return try $0.performUnboxingWithContext(context)
-    })
+public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
+    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 // MARK: - Error type
@@ -324,6 +316,56 @@ public class Unboxer {
         self.dictionary = dictionary
         self.context = context
         self.allowInvalidElements = allowInvalidElements
+    }
+    
+    // MARK: - Private unboxing
+
+    /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxing()
+    }
+
+    /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithDictionary<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return allowInvalidElements
+            ? dictionaries.flatMap { try? performUnboxingWithDictionary($0, context: context) }
+            : try dictionaries.map { try performUnboxingWithDictionary($0, context: context) }
+    }
+
+    /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    }
+
+    /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
+            return try $0.performUnboxing()
+        }
+    }
+
+    /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxingWithContext(context)
+    }
+
+    /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return allowInvalidElements
+            ? dictionaries.flatMap { try? UnboxOrThrow($0, context: context) }
+            : try dictionaries.map { try UnboxOrThrow($0, context: context) }
+    }
+
+    /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    }
+
+    /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
+    private static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
+            return try $0.performUnboxingWithContext(context)
+        }
     }
     
     // MARK: - Custom unboxing API

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -29,90 +29,90 @@ import Foundation
 import CoreGraphics
 
 /// Type alias defining what type of Dictionary that is Unboxable (valid JSON)
-public typealias UnboxableDictionary = [String: AnyObject]
+public typealias UnboxableDictionary = [String : AnyObject]
 
 // MARK: - Main Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
-    return Unboxer.unbox(dictionary, context: context)
+    return try? Unboxer.performUnboxingWithDictionary(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return Unboxer.unbox(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDictionaries(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
-    return Unboxer.unbox(data, context: context)
+    return try? Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return Unboxer.unbox(data, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithData(data, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
-    return Unboxer.unbox(dictionary, context: context)
+    return try? Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return Unboxer.unbox(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
-    return Unboxer.unbox(data, context: context)
+    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return Unboxer.unbox(data, context: context, allowInvalidElements: allowInvalidElements)
+    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 // MARK: - Throwing Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-    return try Unboxer.unboxOrThrow(dictionary, context: context)
+    return try Unboxer.performUnboxingWithDictionary(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
-    return try Unboxer.unboxOrThrow(dictionaries, context: context)
+    return try Unboxer.performUnboxingWithDictionaries(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-    return try Unboxer.unboxOrThrow(data, context: context)
+    return try Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
-    return try Unboxer.unboxOrThrow(data, context: context)
+    return try Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-    return try Unboxer.unboxOrThrow(dictionary, context: context)
+    return try Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
-    return try Unboxer.unboxOrThrow(dictionaries, context: context)
+    return try Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-    return try Unboxer.unboxOrThrow(data, context: context)
+    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
-    return try Unboxer.unboxOrThrow(data, context: context)
+    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 // MARK: - Error type
@@ -121,7 +121,7 @@ public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.Conte
 public enum UnboxError: ErrorType, CustomStringConvertible {
     public var description: String {
         let baseDescription = "[Unbox error] "
-
+        
         switch self {
         case .MissingKey(let key):
             return baseDescription + "Missing key (\(key))"
@@ -133,7 +133,7 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
             return "A custom unboxing closure returned nil"
         }
     }
-
+    
     /// Thrown when a required key was missing in an unboxed dictionary. Contains the missing key.
     case MissingKey(String)
     /// Thrown when a required key contained an invalid value in an unboxed dictionary. Contains the invalid
@@ -157,7 +157,7 @@ public protocol Unboxable {
 public protocol UnboxableWithContext {
     /// The type of the contextual object that this model requires when unboxed
     associatedtype ContextType
-
+    
     /// Initialize an instance of this model by unboxing a dictionary & using a context
     init(unboxer: Unboxer, context: ContextType)
 }
@@ -169,10 +169,10 @@ public protocol UnboxCompatibleType {
 }
 
 /// Protocol used to enable a raw type for Unboxing. See default implementations further down.
-public protocol UnboxableRawType: UnboxCompatibleType { }
+public protocol UnboxableRawType: UnboxCompatibleType {}
 
 /// Protocol used to enable an enum to be directly unboxable
-public protocol UnboxableEnum: RawRepresentable, UnboxCompatibleType { }
+public protocol UnboxableEnum: RawRepresentable, UnboxCompatibleType {}
 
 /// Protocol used to enable any type to be transformed from a JSON key into a dictionary key
 public protocol UnboxableKey: Hashable, UnboxCompatibleType {
@@ -184,7 +184,7 @@ public protocol UnboxableKey: Hashable, UnboxCompatibleType {
 public protocol UnboxableByTransform: UnboxCompatibleType {
     /// The type of raw value that this type can be transformed from
     associatedtype UnboxRawValueType: UnboxableRawType
-
+    
     /// Attempt to transform a raw unboxed value into an instance of this type
     static func transformUnboxedValue(unboxedValue: UnboxRawValueType) -> Self?
 }
@@ -201,7 +201,7 @@ public protocol UnboxFormatter {
     associatedtype UnboxRawValueType: UnboxableRawType
     /// The type of value that this formatter produces as output
     associatedtype UnboxFormattedType
-
+    
     /// Format an unboxed value into another value (or nil if the formatting failed)
     func formatUnboxedValue(unboxedValue: UnboxRawValueType) -> UnboxFormattedType?
 }
@@ -253,11 +253,11 @@ extension String: UnboxableRawType {
 /// Extension making NSURL Unboxable by transform
 extension NSURL: UnboxableByTransform {
     public typealias UnboxRawValueType = String
-
+    
     public static func transformUnboxedValue(rawValue: String) -> Self? {
         return self.init(string: rawValue)
     }
-
+    
     public static func unboxFallbackValue() -> Self {
         return self.init()
     }
@@ -273,7 +273,7 @@ extension String: UnboxableKey {
 /// Extension making NSDate unboxable with an NSDateFormatter
 extension NSDate: UnboxableWithFormatter {
     public typealias UnboxFormatterType = NSDateFormatter
-
+    
     public static func unboxFallbackValue() -> Self {
         return self.init()
     }
@@ -305,235 +305,235 @@ public class Unboxer {
     public var hasFailed: Bool { return self.failureInfo != nil }
     /// Any contextual object that was supplied when unboxing was started
     public let context: Any?
-
+    
     private var failureInfo: (key: String, value: Any?)?
-
+    
     // MARK: - Private initializer
-
+    
     private init(dictionary: UnboxableDictionary, context: Any?) {
         self.dictionary = dictionary
         self.context = context
     }
-
+    
     // MARK: - Custom unboxing API
-
+    
     /// Perform custom unboxing using an Unboxer (created from a dictionary) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithDictionary<T>(dictionary: UnboxableDictionary, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure)
+        return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure, allowInvalidElements: false)
     }
-
+    
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, or throw an UnboxError
     public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer -> T?) throws -> [T] {
         var unboxedArray = [T]()
-
+        
         for dictionary in array {
             let unboxed = try self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
             unboxedArray.append(unboxed)
         }
-
+        
         return unboxedArray
     }
-
+    
     /// Perform custom unboxing using an Unboxer (created from NSData) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithData<T>(data: NSData, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure)
+        return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure, allowInvalidElements: false)
     }
-
+    
     // MARK: - Value accessing API
-
+    
     /// Unbox a required raw type
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<T>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue())
     }
-
+    
     /// Unbox an optional raw type
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<T>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath)
     }
-
+    
     /// Unbox a required Array of raw values
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [])
     }
-
+    
     /// Unbox an optional Array of raw values
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath)
     }
-
+    
     /// Unbox a required raw value from a certain index in a nested Array
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false, index: Int) -> T {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             if index < 0 || index >= $0.count {
                 return nil
             }
-
+            
             return $0[index]
         })
     }
-
+    
     /// Unbox an optional raw value from a certain index in a nested Array
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false, index: Int) -> T? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             if index < 0 || index >= $0.count {
                 return nil
             }
-
+            
             return $0[index]
         })
     }
-
+    
     /// Unbox a required Dictionary with untyped values, without applying a transform on them
-    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K: AnyObject] {
+    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K : AnyObject] {
         return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: { $0 }) ?? [:]
     }
-
+    
     /// Unbox an optional Dictionary with untyped values, without applying a transform on them
-    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K: AnyObject]? {
+    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K : AnyObject]? {
         return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: { $0 })
     }
-
+    
     /// Unbox a required Dictionary with raw values
-    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K: V] {
+    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K : V] {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: { $0 }) ?? [:]
     }
-
+    
     /// Unbox an optional Dictionary with raw values
-    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K: V]? {
+    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K : V]? {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: { $0 })
     }
-
+    
     /// Unbox a required enum value
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<T.RawValue>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return T(rawValue: $0)
         })
     }
-
+    
     /// Unbox an optional enum value
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<T.RawValue>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return T(rawValue: $0)
         })
     }
-
+    
     /// Unbox a required Array of enum raw values to an Array of enums using a transform
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[T.RawValue]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: { (array) -> [T]? in
-            return array.flatMap { T(rawValue: $0) }
+            return array.flatMap({ T(rawValue: $0) })
         })
     }
-
+    
     /// Unbox an optional Array of enum raw values to an Array of enums using a transform
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[T.RawValue]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: { (array) -> [T]? in
-            return array.flatMap { T(rawValue: $0) }
+            return array.flatMap({ T(rawValue: $0) })
         })
     }
-
+    
     /// Unbox a required nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return Unbox($0, context: self.context)
         })
     }
-
+    
     /// Unbox an optional nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: self.context)
         })
     }
-
+    
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
             return Unbox($0, context: self.context)
         })
     }
-
+    
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: self.context)
         })
     }
-
+    
     /// Unbox a required Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K: V] {
+    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K : V] {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: {
             return Unbox($0, context: self.context)
         }) ?? [:]
     }
-
+    
     /// Unbox an optional Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K: V]? {
+    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K : V]? {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: {
             return Unbox($0, context: self.context)
         })
     }
-
+    
     /// Unbox a required nested UnboxableWithContext type
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> T {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValueWithContext(context), transform: {
             return Unbox($0, context: context)
         })
     }
-
+    
     /// Unbox an optional nested UnboxableWithContext type
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> T? {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: context)
         })
     }
-
+    
     /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
             return Unbox($0, context: context)
         })
     }
-
+    
     /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: context)
         })
     }
-
+    
     /// Unbox a required value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return T.transformUnboxedValue($0)
         })
     }
-
+    
     /// Unbox an optional value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return T.transformUnboxedValue($0)
         })
     }
-
+    
     /// Unbox a required value that can be formatted using a formatter
-    public func unbox < T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T > (key: String, isKeyPath: Bool = false, formatter: F) -> T {
+    public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, isKeyPath: Bool = false, formatter: F) -> T {
         return UnboxValueResolver<F.UnboxRawValueType>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return formatter.formatUnboxedValue($0)
         })
     }
-
+    
     /// Unbox an optional value that can be formatted using a formatter
-    public func unbox < T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T > (key: String, isKeyPath: Bool = false, formatter: F) -> T? {
+    public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, isKeyPath: Bool = false, formatter: F) -> T? {
         return UnboxValueResolver<F.UnboxRawValueType>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return formatter.formatUnboxedValue($0)
         })
     }
-
+    
     /// Make this Unboxer fail for a certain key. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForKey(key: String) {
         self.failForInvalidValue(nil, forKey: key)
     }
-
+    
     /// Make this Unboxer fail for a certain key and invalid value. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForInvalidValue(invalidValue: Any?, forKey key: String) {
         self.failureInfo = (key, invalidValue)
@@ -544,33 +544,33 @@ public class Unboxer {
 
 private class UnboxValueResolver<T> {
     let unboxer: Unboxer
-
+    
     init(_ unboxer: Unboxer) {
         self.unboxer = unboxer
     }
-
+    
     func resolveRequiredValueForKey(key: String, isKeyPath: Bool, @autoclosure fallbackValue: () -> T) -> T {
         return self.resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: fallbackValue, transform: {
             return $0
         })
     }
-
+    
     func resolveRequiredValueForKey<R>(key: String, isKeyPath: Bool, @autoclosure fallbackValue: () -> R, transform: T -> R?) -> R {
         if let value = self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: transform) {
             return value
         }
-
+        
         self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
-
+        
         return fallbackValue()
     }
-
+    
     func resolveOptionalValueForKey(key: String, isKeyPath: Bool) -> T? {
         return self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return $0
         })
     }
-
+    
     func resolveOptionalValueForKey<R>(key: String, isKeyPath: Bool, transform: T -> R?) -> R? {
         var dictionary = self.unboxer.dictionary
         var modifiedKey = key
@@ -579,7 +579,7 @@ private class UnboxValueResolver<T> {
             let components = key.componentsSeparatedByString(".")
             for i in 0 ..< components.count {
                 let keyPathComponent = components[i]
-
+                
                 if i == components.count - 1 {
                     modifiedKey = keyPathComponent
                 } else if let nestedDictionary = dictionary[keyPathComponent] as? UnboxableDictionary {
@@ -595,33 +595,33 @@ private class UnboxValueResolver<T> {
                 return transformed
             }
         }
-
+        
         return nil
     }
 }
 
 extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConvertible, T.Key == String, T.Generator == DictionaryGenerator<T.Key, T.Value> {
-    func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, isKeyPath: Bool, required: Bool, valueTransform: T.Value -> V?) -> [K: V]? {
+    func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, isKeyPath: Bool, required: Bool, valueTransform: T.Value -> V?) -> [K : V]? {
         if let unboxedDictionary = self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath) {
-            var transformedDictionary = [K: V]()
-
+            var transformedDictionary = [K : V]()
+            
             for (unboxedKey, unboxedValue) in unboxedDictionary {
                 guard let transformedKey = K.transformUnboxedKey(unboxedKey), transformedValue = valueTransform(unboxedValue) else {
                     if required {
                         self.unboxer.failForInvalidValue(unboxedDictionary, forKey: key)
                     }
-
+                    
                     return nil
                 }
-
+                
                 transformedDictionary[transformedKey] = transformedValue
             }
-
+            
             return transformedDictionary
         } else if required {
             self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
         }
-
+        
         return [:]
     }
 }
@@ -646,132 +646,102 @@ private extension Unboxer {
             guard let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary else {
                 throw UnboxError.InvalidData
             }
-
+            
             return Unboxer(dictionary: dictionary, context: context)
         } catch {
             throw UnboxError.InvalidData
         }
     }
-
+    
     static func unboxersFromData(data: NSData, context: Any?) throws -> [Unboxer] {
         do {
             guard let array = try NSJSONSerialization.JSONObjectWithData(data, options: [.AllowFragments]) as? [UnboxableDictionary] else {
                 throw UnboxError.InvalidData
             }
-
-            return array.map { Unboxer(dictionary: $0, context: context) }
+            
+            return array.map({
+                return Unboxer(dictionary: $0, context: context)
+            })
         } catch {
             throw UnboxError.InvalidData
         }
     }
 
-    // MARK: - Main Unbox functions
-
-    static func unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
-        return try? Unboxer.unboxOrThrow(dictionary, context: context)
+    static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil, allowInvalidElements: Bool = false) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context).performUnboxing(allowInvalidElements)
     }
 
-    static func unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-        return allowInvalidElements
-            ? dictionaries.flatMap { unbox($0, context: context) }
-            : try? Unboxer.unboxOrThrow(dictionaries, context: context)
+    static func performUnboxingWithDictionaries<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return try dictionaries.map {
+            try performUnboxingWithDictionary($0, context: context, allowInvalidElements: allowInvalidElements)
+        }
     }
 
-    static func unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
-        return try? Unboxer.unboxOrThrow(data, context: context)
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxing(allowInvalidElements)
     }
 
-    static func unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-        return allowInvalidElements
-            ? try? Unboxer.unboxersFromData(data, context: context).flatMap { try? $0.performUnboxing() } ?? []
-            : try? Unboxer.unboxOrThrow(data, context: context)
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context).map {
+            return try $0.performUnboxing(allowInvalidElements)
+        }
     }
 
-    static func unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
-        return try? Unboxer.unboxOrThrow(dictionary, context: context)
+    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType, allowInvalidElements: Bool = false) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context, allowInvalidElements: allowInvalidElements)
     }
 
-    static func unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-        return allowInvalidElements
-            ? dictionaries.flatMap { unbox($0, context: context) }
-            : try? Unboxer.unboxOrThrow(dictionaries, context: context)
+    static func performUnboxingWithDictionariesAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return try dictionaries.map {
+            try performUnboxingWithDictionaryAndContext($0, context: context, allowInvalidElements: allowInvalidElements)
+        }
     }
 
-    static func unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
-        return try? Unboxer.unboxOrThrow(data, context: context)
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context, allowInvalidElements: allowInvalidElements)
     }
 
-    static func unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-        return allowInvalidElements
-            ? try? Unboxer.unboxersFromData(data, context: context).flatMap { try? $0.performUnboxingWithContext(context) } ?? []
-            : try? Unboxer.unboxOrThrow(data, context: context)
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context).map {
+            return try $0.performUnboxingWithContext(context, allowInvalidElements: allowInvalidElements)
+        }
     }
-
-    // MARK: - Throwing Unbox functions
-
-    static func unboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
-    }
-
-    static func unboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
-        return try dictionaries.map { try unboxOrThrow($0, context: context) }
-    }
-
-    static func unboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
-    }
-
-    static func unboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context).map { try $0.performUnboxing() }
-    }
-
-    static func unboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
-    }
-
-    static func unboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
-        return try dictionaries.map { try unboxOrThrow($0, context: context) }
-    }
-
-    static func unboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
-    }
-
-    static func unboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context).map { try $0.performUnboxingWithContext(context) }
-    }
-
-    func performUnboxing<T: Unboxable>() throws -> T {
+    
+    func performUnboxing<T: Unboxable>(allowInvalidElements: Bool) throws -> T {
         let unboxed = T(unboxer: self)
-        try self.throwIfFailed()
+        try self.throwIfFailed(allowInvalidElements)
         return unboxed
     }
-
-    func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType) throws -> T {
+    
+    func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType, allowInvalidElements: Bool) throws -> T {
         let unboxed = T(unboxer: self, context: context)
-        try self.throwIfFailed()
+        try self.throwIfFailed(allowInvalidElements)
         return unboxed
     }
-
-    func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?) throws -> T {
+    
+    func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?, allowInvalidElements: Bool) throws -> T {
         guard let unboxed: T = closure(self) else {
             throw UnboxError.CustomUnboxingFailed
         }
-
-        try self.throwIfFailed()
-
+        
+        try self.throwIfFailed(allowInvalidElements)
+        
         return unboxed
     }
-
-    func throwIfFailed() throws {
+    
+    func throwIfFailed(allowInvalidElements: Bool) throws {
         guard let failureInfo = self.failureInfo else {
             return
         }
-
+        
+        if allowInvalidElements {
+            return
+        }
+        
         if let failedValue: Any = failureInfo.value {
             throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
         }
-
+        
         throw UnboxError.MissingKey(failureInfo.key)
     }
 }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -29,90 +29,90 @@ import Foundation
 import CoreGraphics
 
 /// Type alias defining what type of Dictionary that is Unboxable (valid JSON)
-public typealias UnboxableDictionary = [String : AnyObject]
+public typealias UnboxableDictionary = [String: AnyObject]
 
 // MARK: - Main Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
-    return try? Unboxer.performUnboxingWithDictionary(dictionary, context: context)
+    return Unboxer.unbox(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return try? Unboxer.performUnboxingWithDictionaries(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return Unboxer.unbox(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
-    return try? Unboxer.performUnboxingWithData(data, context: context)
+    return Unboxer.unbox(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
-    return try? Unboxer.performUnboxingWithData(data, context: context, allowInvalidElements: allowInvalidElements)
+    return Unboxer.unbox(data, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
-    return try? Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
+    return Unboxer.unbox(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return try? Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
+    return Unboxer.unbox(dictionaries, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
-    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context)
+    return Unboxer.unbox(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
-    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context, allowInvalidElements: allowInvalidElements)
+    return Unboxer.unbox(data, context: context, allowInvalidElements: allowInvalidElements)
 }
 
 // MARK: - Throwing Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-    return try Unboxer.performUnboxingWithDictionary(dictionary, context: context)
+    return try Unboxer.unboxOrThrow(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
-    return try Unboxer.performUnboxingWithDictionaries(dictionaries, context: context)
+    return try Unboxer.unboxOrThrow(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-    return try Unboxer.performUnboxingWithData(data, context: context)
+    return try Unboxer.unboxOrThrow(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
-    return try Unboxer.performUnboxingWithData(data, context: context)
+    return try Unboxer.unboxOrThrow(data, context: context)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-    return try Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
+    return try Unboxer.unboxOrThrow(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
-    return try Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context)
+    return try Unboxer.unboxOrThrow(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
+    return try Unboxer.unboxOrThrow(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
-    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
+    return try Unboxer.unboxOrThrow(data, context: context)
 }
 
 // MARK: - Error type
@@ -121,7 +121,7 @@ public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.Conte
 public enum UnboxError: ErrorType, CustomStringConvertible {
     public var description: String {
         let baseDescription = "[Unbox error] "
-        
+
         switch self {
         case .MissingKey(let key):
             return baseDescription + "Missing key (\(key))"
@@ -133,7 +133,7 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
             return "A custom unboxing closure returned nil"
         }
     }
-    
+
     /// Thrown when a required key was missing in an unboxed dictionary. Contains the missing key.
     case MissingKey(String)
     /// Thrown when a required key contained an invalid value in an unboxed dictionary. Contains the invalid
@@ -157,7 +157,7 @@ public protocol Unboxable {
 public protocol UnboxableWithContext {
     /// The type of the contextual object that this model requires when unboxed
     associatedtype ContextType
-    
+
     /// Initialize an instance of this model by unboxing a dictionary & using a context
     init(unboxer: Unboxer, context: ContextType)
 }
@@ -169,10 +169,10 @@ public protocol UnboxCompatibleType {
 }
 
 /// Protocol used to enable a raw type for Unboxing. See default implementations further down.
-public protocol UnboxableRawType: UnboxCompatibleType {}
+public protocol UnboxableRawType: UnboxCompatibleType { }
 
 /// Protocol used to enable an enum to be directly unboxable
-public protocol UnboxableEnum: RawRepresentable, UnboxCompatibleType {}
+public protocol UnboxableEnum: RawRepresentable, UnboxCompatibleType { }
 
 /// Protocol used to enable any type to be transformed from a JSON key into a dictionary key
 public protocol UnboxableKey: Hashable, UnboxCompatibleType {
@@ -184,7 +184,7 @@ public protocol UnboxableKey: Hashable, UnboxCompatibleType {
 public protocol UnboxableByTransform: UnboxCompatibleType {
     /// The type of raw value that this type can be transformed from
     associatedtype UnboxRawValueType: UnboxableRawType
-    
+
     /// Attempt to transform a raw unboxed value into an instance of this type
     static func transformUnboxedValue(unboxedValue: UnboxRawValueType) -> Self?
 }
@@ -201,7 +201,7 @@ public protocol UnboxFormatter {
     associatedtype UnboxRawValueType: UnboxableRawType
     /// The type of value that this formatter produces as output
     associatedtype UnboxFormattedType
-    
+
     /// Format an unboxed value into another value (or nil if the formatting failed)
     func formatUnboxedValue(unboxedValue: UnboxRawValueType) -> UnboxFormattedType?
 }
@@ -253,11 +253,11 @@ extension String: UnboxableRawType {
 /// Extension making NSURL Unboxable by transform
 extension NSURL: UnboxableByTransform {
     public typealias UnboxRawValueType = String
-    
+
     public static func transformUnboxedValue(rawValue: String) -> Self? {
         return self.init(string: rawValue)
     }
-    
+
     public static func unboxFallbackValue() -> Self {
         return self.init()
     }
@@ -273,7 +273,7 @@ extension String: UnboxableKey {
 /// Extension making NSDate unboxable with an NSDateFormatter
 extension NSDate: UnboxableWithFormatter {
     public typealias UnboxFormatterType = NSDateFormatter
-    
+
     public static func unboxFallbackValue() -> Self {
         return self.init()
     }
@@ -305,235 +305,235 @@ public class Unboxer {
     public var hasFailed: Bool { return self.failureInfo != nil }
     /// Any contextual object that was supplied when unboxing was started
     public let context: Any?
-    
+
     private var failureInfo: (key: String, value: Any?)?
-    
+
     // MARK: - Private initializer
-    
+
     private init(dictionary: UnboxableDictionary, context: Any?) {
         self.dictionary = dictionary
         self.context = context
     }
-    
+
     // MARK: - Custom unboxing API
-    
+
     /// Perform custom unboxing using an Unboxer (created from a dictionary) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithDictionary<T>(dictionary: UnboxableDictionary, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure, allowInvalidElements: false)
+        return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure)
     }
-    
+
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, or throw an UnboxError
     public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer -> T?) throws -> [T] {
         var unboxedArray = [T]()
-        
+
         for dictionary in array {
             let unboxed = try self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
             unboxedArray.append(unboxed)
         }
-        
+
         return unboxedArray
     }
-    
+
     /// Perform custom unboxing using an Unboxer (created from NSData) passed to a closure, or throw an UnboxError
     public static func performCustomUnboxingWithData<T>(data: NSData, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure, allowInvalidElements: false)
+        return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure)
     }
-    
+
     // MARK: - Value accessing API
-    
+
     /// Unbox a required raw type
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<T>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue())
     }
-    
+
     /// Unbox an optional raw type
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<T>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath)
     }
-    
+
     /// Unbox a required Array of raw values
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [])
     }
-    
+
     /// Unbox an optional Array of raw values
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath)
     }
-    
+
     /// Unbox a required raw value from a certain index in a nested Array
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false, index: Int) -> T {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             if index < 0 || index >= $0.count {
                 return nil
             }
-            
+
             return $0[index]
         })
     }
-    
+
     /// Unbox an optional raw value from a certain index in a nested Array
     public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false, index: Int) -> T? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             if index < 0 || index >= $0.count {
                 return nil
             }
-            
+
             return $0[index]
         })
     }
-    
+
     /// Unbox a required Dictionary with untyped values, without applying a transform on them
-    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K : AnyObject] {
+    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K: AnyObject] {
         return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: { $0 }) ?? [:]
     }
-    
+
     /// Unbox an optional Dictionary with untyped values, without applying a transform on them
-    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K : AnyObject]? {
+    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K: AnyObject]? {
         return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: { $0 })
     }
-    
+
     /// Unbox a required Dictionary with raw values
-    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K : V] {
+    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K: V] {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: { $0 }) ?? [:]
     }
-    
+
     /// Unbox an optional Dictionary with raw values
-    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K : V]? {
+    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K: V]? {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: { $0 })
     }
-    
+
     /// Unbox a required enum value
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<T.RawValue>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return T(rawValue: $0)
         })
     }
-    
+
     /// Unbox an optional enum value
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<T.RawValue>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return T(rawValue: $0)
         })
     }
-    
+
     /// Unbox a required Array of enum raw values to an Array of enums using a transform
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[T.RawValue]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: { (array) -> [T]? in
-            return array.flatMap({ T(rawValue: $0) })
+            return array.flatMap { T(rawValue: $0) }
         })
     }
-    
+
     /// Unbox an optional Array of enum raw values to an Array of enums using a transform
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[T.RawValue]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: { (array) -> [T]? in
-            return array.flatMap({ T(rawValue: $0) })
+            return array.flatMap { T(rawValue: $0) }
         })
     }
-    
+
     /// Unbox a required nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox an optional nested Unboxable, by unboxing a Dictionary and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox a required Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K : V] {
+    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K: V] {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: {
             return Unbox($0, context: self.context)
         }) ?? [:]
     }
-    
+
     /// Unbox an optional Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K : V]? {
+    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false) -> [K: V]? {
         return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: {
             return Unbox($0, context: self.context)
         })
     }
-    
+
     /// Unbox a required nested UnboxableWithContext type
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> T {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValueWithContext(context), transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox an optional nested UnboxableWithContext type
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> T? {
         return UnboxValueResolver<UnboxableDictionary>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return Unbox($0, context: context)
         })
     }
-    
+
     /// Unbox a required value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String, isKeyPath: Bool = false) -> T {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return T.transformUnboxedValue($0)
         })
     }
-    
+
     /// Unbox an optional value that can be transformed into its final form
     public func unbox<T: UnboxableByTransform>(key: String, isKeyPath: Bool = false) -> T? {
         return UnboxValueResolver<T.UnboxRawValueType>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return T.transformUnboxedValue($0)
         })
     }
-    
+
     /// Unbox a required value that can be formatted using a formatter
-    public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, isKeyPath: Bool = false, formatter: F) -> T {
+    public func unbox < T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T > (key: String, isKeyPath: Bool = false, formatter: F) -> T {
         return UnboxValueResolver<F.UnboxRawValueType>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: T.unboxFallbackValue(), transform: {
             return formatter.formatUnboxedValue($0)
         })
     }
-    
+
     /// Unbox an optional value that can be formatted using a formatter
-    public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, isKeyPath: Bool = false, formatter: F) -> T? {
+    public func unbox < T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T > (key: String, isKeyPath: Bool = false, formatter: F) -> T? {
         return UnboxValueResolver<F.UnboxRawValueType>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return formatter.formatUnboxedValue($0)
         })
     }
-    
+
     /// Make this Unboxer fail for a certain key. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForKey(key: String) {
         self.failForInvalidValue(nil, forKey: key)
     }
-    
+
     /// Make this Unboxer fail for a certain key and invalid value. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForInvalidValue(invalidValue: Any?, forKey key: String) {
         self.failureInfo = (key, invalidValue)
@@ -544,33 +544,33 @@ public class Unboxer {
 
 private class UnboxValueResolver<T> {
     let unboxer: Unboxer
-    
+
     init(_ unboxer: Unboxer) {
         self.unboxer = unboxer
     }
-    
+
     func resolveRequiredValueForKey(key: String, isKeyPath: Bool, @autoclosure fallbackValue: () -> T) -> T {
         return self.resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: fallbackValue, transform: {
             return $0
         })
     }
-    
+
     func resolveRequiredValueForKey<R>(key: String, isKeyPath: Bool, @autoclosure fallbackValue: () -> R, transform: T -> R?) -> R {
         if let value = self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: transform) {
             return value
         }
-        
+
         self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
-        
+
         return fallbackValue()
     }
-    
+
     func resolveOptionalValueForKey(key: String, isKeyPath: Bool) -> T? {
         return self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return $0
         })
     }
-    
+
     func resolveOptionalValueForKey<R>(key: String, isKeyPath: Bool, transform: T -> R?) -> R? {
         var dictionary = self.unboxer.dictionary
         var modifiedKey = key
@@ -579,7 +579,7 @@ private class UnboxValueResolver<T> {
             let components = key.componentsSeparatedByString(".")
             for i in 0 ..< components.count {
                 let keyPathComponent = components[i]
-                
+
                 if i == components.count - 1 {
                     modifiedKey = keyPathComponent
                 } else if let nestedDictionary = dictionary[keyPathComponent] as? UnboxableDictionary {
@@ -595,33 +595,33 @@ private class UnboxValueResolver<T> {
                 return transformed
             }
         }
-        
+
         return nil
     }
 }
 
 extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConvertible, T.Key == String, T.Generator == DictionaryGenerator<T.Key, T.Value> {
-    func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, isKeyPath: Bool, required: Bool, valueTransform: T.Value -> V?) -> [K : V]? {
+    func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, isKeyPath: Bool, required: Bool, valueTransform: T.Value -> V?) -> [K: V]? {
         if let unboxedDictionary = self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath) {
-            var transformedDictionary = [K : V]()
-            
+            var transformedDictionary = [K: V]()
+
             for (unboxedKey, unboxedValue) in unboxedDictionary {
                 guard let transformedKey = K.transformUnboxedKey(unboxedKey), transformedValue = valueTransform(unboxedValue) else {
                     if required {
                         self.unboxer.failForInvalidValue(unboxedDictionary, forKey: key)
                     }
-                    
+
                     return nil
                 }
-                
+
                 transformedDictionary[transformedKey] = transformedValue
             }
-            
+
             return transformedDictionary
         } else if required {
             self.unboxer.failForInvalidValue(self.unboxer.dictionary[key], forKey: key)
         }
-        
+
         return [:]
     }
 }
@@ -646,102 +646,132 @@ private extension Unboxer {
             guard let dictionary = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? UnboxableDictionary else {
                 throw UnboxError.InvalidData
             }
-            
+
             return Unboxer(dictionary: dictionary, context: context)
         } catch {
             throw UnboxError.InvalidData
         }
     }
-    
+
     static func unboxersFromData(data: NSData, context: Any?) throws -> [Unboxer] {
         do {
             guard let array = try NSJSONSerialization.JSONObjectWithData(data, options: [.AllowFragments]) as? [UnboxableDictionary] else {
                 throw UnboxError.InvalidData
             }
-            
-            return array.map({
-                return Unboxer(dictionary: $0, context: context)
-            })
+
+            return array.map { Unboxer(dictionary: $0, context: context) }
         } catch {
             throw UnboxError.InvalidData
         }
     }
 
-    static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil, allowInvalidElements: Bool = false) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performUnboxing(allowInvalidElements)
+    // MARK: - Main Unbox functions
+
+    static func unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
+        return try? Unboxer.unboxOrThrow(dictionary, context: context)
     }
 
-    static func performUnboxingWithDictionaries<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-        return try dictionaries.map {
-            try performUnboxingWithDictionary($0, context: context, allowInvalidElements: allowInvalidElements)
-        }
+    static func unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
+        return allowInvalidElements
+            ? dictionaries.flatMap { unbox($0, context: context) }
+            : try? Unboxer.unboxOrThrow(dictionaries, context: context)
     }
 
-    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxing(allowInvalidElements)
+    static func unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
+        return try? Unboxer.unboxOrThrow(data, context: context)
     }
 
-    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context).map {
-            return try $0.performUnboxing(allowInvalidElements)
-        }
+    static func unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) -> [T]? {
+        return allowInvalidElements
+            ? try? Unboxer.unboxersFromData(data, context: context).flatMap { try? $0.performUnboxing() } ?? []
+            : try? Unboxer.unboxOrThrow(data, context: context)
     }
 
-    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType, allowInvalidElements: Bool = false) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context, allowInvalidElements: allowInvalidElements)
+    static func unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
+        return try? Unboxer.unboxOrThrow(dictionary, context: context)
     }
 
-    static func performUnboxingWithDictionariesAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-        return try dictionaries.map {
-            try performUnboxingWithDictionaryAndContext($0, context: context, allowInvalidElements: allowInvalidElements)
-        }
+    static func unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
+        return allowInvalidElements
+            ? dictionaries.flatMap { unbox($0, context: context) }
+            : try? Unboxer.unboxOrThrow(dictionaries, context: context)
     }
 
-    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context, allowInvalidElements: allowInvalidElements)
+    static func unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
+        return try? Unboxer.unboxOrThrow(data, context: context)
     }
 
-    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context).map {
-            return try $0.performUnboxingWithContext(context, allowInvalidElements: allowInvalidElements)
-        }
+    static func unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
+        return allowInvalidElements
+            ? try? Unboxer.unboxersFromData(data, context: context).flatMap { try? $0.performUnboxingWithContext(context) } ?? []
+            : try? Unboxer.unboxOrThrow(data, context: context)
     }
-    
-    func performUnboxing<T: Unboxable>(allowInvalidElements: Bool) throws -> T {
+
+    // MARK: - Throwing Unbox functions
+
+    static func unboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
+    }
+
+    static func unboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
+        return try dictionaries.map { try unboxOrThrow($0, context: context) }
+    }
+
+    static func unboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    }
+
+    static func unboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context).map { try $0.performUnboxing() }
+    }
+
+    static func unboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
+    }
+
+    static func unboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
+        return try dictionaries.map { try unboxOrThrow($0, context: context) }
+    }
+
+    static func unboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    }
+
+    static func unboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context).map { try $0.performUnboxingWithContext(context) }
+    }
+
+    func performUnboxing<T: Unboxable>() throws -> T {
         let unboxed = T(unboxer: self)
-        try self.throwIfFailed(allowInvalidElements)
+        try self.throwIfFailed()
         return unboxed
     }
-    
-    func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType, allowInvalidElements: Bool) throws -> T {
+
+    func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType) throws -> T {
         let unboxed = T(unboxer: self, context: context)
-        try self.throwIfFailed(allowInvalidElements)
+        try self.throwIfFailed()
         return unboxed
     }
-    
-    func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?, allowInvalidElements: Bool) throws -> T {
+
+    func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?) throws -> T {
         guard let unboxed: T = closure(self) else {
             throw UnboxError.CustomUnboxingFailed
         }
-        
-        try self.throwIfFailed(allowInvalidElements)
-        
+
+        try self.throwIfFailed()
+
         return unboxed
     }
-    
-    func throwIfFailed(allowInvalidElements: Bool) throws {
+
+    func throwIfFailed() throws {
         guard let failureInfo = self.failureInfo else {
             return
         }
-        
-        if allowInvalidElements {
-            return
-        }
-        
+
         if let failedValue: Any = failureInfo.value {
             throw UnboxError.InvalidValue(failureInfo.key, "\(failedValue)")
         }
-        
+
         throw UnboxError.MissingKey(failureInfo.key)
     }
 }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -669,6 +669,58 @@ private extension Unboxer {
             throw UnboxError.InvalidData
         }
     }
+
+    static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxing()
+    }
+
+    static func performUnboxingWithDictionary<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        if allowInvalidElements {
+            return dictionaries.flatMap {
+                try? performUnboxingWithDictionary($0, context: context)
+            }
+        }
+        
+        return try dictionaries.map {
+            try performUnboxingWithDictionary($0, context: context)
+        }
+    }
+
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    }
+
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
+            return try $0.performUnboxing()
+        }
+    }
+
+    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxingWithContext(context)
+    }
+
+    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        if allowInvalidElements {
+            return dictionaries.flatMap {
+                try? UnboxOrThrow($0, context: context)
+            }
+        }
+        
+        return try dictionaries.map {
+            try UnboxOrThrow($0, context: context)
+        }
+    }
+
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    }
+
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
+            return try $0.performUnboxingWithContext(context)
+        }
+    }
     
     func performUnboxing<T: Unboxable>() throws -> T {
         let unboxed = T(unboxer: self)
@@ -690,54 +742,6 @@ private extension Unboxer {
         try self.throwIfFailed()
         
         return unboxed
-    }
-
-    /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
-    static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxing()
-    }
-
-    /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
-    static func performUnboxingWithDictionary<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-        return allowInvalidElements
-            ? dictionaries.flatMap { try? performUnboxingWithDictionary($0, context: context) }
-            : try dictionaries.map { try performUnboxingWithDictionary($0, context: context) }
-    }
-
-    /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
-    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
-    }
-
-    /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
-    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
-            return try $0.performUnboxing()
-        }
-    }
-
-    /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
-    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-        return try Unboxer(dictionary: dictionary, context: context, allowInvalidElements: false).performUnboxingWithContext(context)
-    }
-
-    /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
-    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-        return allowInvalidElements
-            ? dictionaries.flatMap { try? UnboxOrThrow($0, context: context) }
-            : try dictionaries.map { try UnboxOrThrow($0, context: context) }
-    }
-
-    /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
-    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
-    }
-
-    /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
-    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-        return try Unboxer.unboxersFromData(data, context: context, allowInvalidElements: allowInvalidElements).map {
-            return try $0.performUnboxingWithContext(context)
-        }
     }
     
     func throwIfFailed() throws {

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -573,72 +573,57 @@ class UnboxTests: XCTestCase {
         }
     }
     
-    func testUnboxWithAllowInvalidElementsForDictionary() {
+    func testUnboxDictionariesArrayWithObjectsWithFailableProperties() {
         struct Model: Unboxable {
-            let successProperty: String
-            let failedProperty: String
+            let property1: String
+            let property2: String
             
             init(unboxer: Unboxer) {
-                self.successProperty = unboxer.unbox("success")
-                self.failedProperty = unboxer.unbox("notexist")
+                self.property1 = unboxer.unbox("notfailable1")
+                self.property2 = unboxer.unbox("notfailable2")
             }
         }
         
         let array: [UnboxableDictionary] = [
             [
-                "success" : "Hello"
+                "notfailable1" : "Hello",
+                "notfailable2" : "Hello"
             ],
             [
-                "success" : "Unbox"
+                "notfailable1" : "Hello"
             ]
         ]
         
-        guard let items: [Model] = Unbox(array, allowInvalidElements: true) else {
-            XCTFail("Could not unbox collections from data")
-            return
-        }
+        let items: [Model] = Unbox(array, allowInvalidElements: true) ?? []
+        XCTAssert(items.count == 1, "Unbox did not return correct number of valid elements")
         
-        XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
-        
-        guard let items2: [Model] = Unbox(array) else {
-            // Nil expected and correct
-            return
-        }
-        
-        XCTAssert(items2.count > 0, "Unbox should not have return data with invalid data for allowInvalidElements = false")
+        let items2: [Model]? = Unbox(array)
+        XCTAssert(items2 == nil, "Unbox should not return data")
     }
     
-    func testUnboxWithAllowInvalidElementsForData() {
+    func testUnboxDataArrayWithObjectsWithFailableProperties() {
         struct Model: Unboxable {
-            let successProperty: String
-            let failedProperty: String
+            let property1: String
+            let property2: String
             
             init(unboxer: Unboxer) {
-                self.successProperty = unboxer.unbox("success")
-                self.failedProperty = unboxer.unbox("notexist")
+                self.property1 = unboxer.unbox("notfailable1")
+                self.property2 = unboxer.unbox("notfailable2")
             }
         }
         
-        let json = "[{\"success\":\"Hello\"},{\"success\":\"Unbox\"}]"
+        let json = "[{\"notfailable1\":\"Hello\",\"notfailable2\":\"Hello\"},{\"notfailable1\":\"Hello\"}]"
         
         guard let data = json.dataUsingEncoding(NSUTF8StringEncoding) else {
              XCTFail("Could not create data from a string")
              return
         }
         
-        guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
-            XCTFail("Could not unbox collections from data")
-            return
-        }
+        let items: [Model] = Unbox(data, allowInvalidElements: true) ?? []
+        XCTAssert(items.count == 1, "Unbox did not return correct number of valid elements")
         
-        XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
-        
-        guard let items2: [Model] = Unbox(data) else {
-            // Nil expected and correct
-            return
-        }
-        
-        XCTAssert(items2.count > 0, "Unbox should not have return data with invalid data for allowInvalidElements = false")
+        let items2: [Model]? = Unbox(data)
+        XCTAssert(items2 == nil, "Unbox should not return data")
     }
 }
 

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -573,7 +573,7 @@ class UnboxTests: XCTestCase {
         }
     }
     
-    func testUnboxWithAllowInvalidElements() {
+    func testUnboxWithAllowInvalidElementsForDictionary() {
         struct Model: Unboxable {
             let successProperty: String
             let failedProperty: String
@@ -594,6 +594,32 @@ class UnboxTests: XCTestCase {
         ]
         
         guard let items: [Model] = Unbox(array, allowInvalidElements: true) else {
+            XCTFail("Could not unbox collections from data")
+            return
+        }
+        
+        XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
+    }
+    
+    func testUnboxWithAllowInvalidElementsForData() {
+        struct Model: Unboxable {
+            let successProperty: String
+            let failedProperty: String
+            
+            init(unboxer: Unboxer) {
+                self.successProperty = unboxer.unbox("success")
+                self.failedProperty = unboxer.unbox("notexist")
+            }
+        }
+        
+        let json = "[{\"success\":\"Hello\"},{\"success\":\"Unbox\"}]"
+        
+        guard let data = json.dataUsingEncoding(NSUTF8StringEncoding) else {
+             XCTFail("Could not create data from a string")
+             return
+         }
+        
+         guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
             XCTFail("Could not unbox collections from data")
             return
         }

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -599,6 +599,13 @@ class UnboxTests: XCTestCase {
         }
         
         XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
+        
+        guard let items2: [Model] = Unbox(array) else {
+            // Nil expected and correct
+            return
+        }
+        
+        XCTAssert(items2.count > 0, "Unbox should not have return data with invalid data for allowInvalidElements = false")
     }
     
     func testUnboxWithAllowInvalidElementsForData() {
@@ -617,14 +624,21 @@ class UnboxTests: XCTestCase {
         guard let data = json.dataUsingEncoding(NSUTF8StringEncoding) else {
              XCTFail("Could not create data from a string")
              return
-         }
+        }
         
-         guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
+        guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
             XCTFail("Could not unbox collections from data")
             return
         }
         
         XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
+        
+        guard let items2: [Model] = Unbox(data) else {
+            // Nil expected and correct
+            return
+        }
+        
+        XCTAssert(items2.count > 0, "Unbox should not have return data with invalid data for allowInvalidElements = false")
     }
 }
 

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -575,43 +575,30 @@ class UnboxTests: XCTestCase {
     
     func testUnboxWithAllowInvalidElements() {
         struct Model: Unboxable {
-            let id: String
-            let name: String
-            let isActive: Bool
-            let age: Int
-            let registered: NSDate?
-            let tags: [String]
-            let authorLink: String
-            let repliesLink: String
+            let successProperty: String
             let failedProperty: String
             
             init(unboxer: Unboxer) {
-                self.id = unboxer.unbox("id")
-                self.name = unboxer.unbox("name")
-                self.isActive = unboxer.unbox("isActive")
-                self.age = unboxer.unbox("age")
-                self.tags = unboxer.unbox("tags")
-                self.authorLink = unboxer.unbox("meta.link.author", isKeyPath: true)
-                self.repliesLink = unboxer.unbox("meta.link.replies", isKeyPath: true)
-                self.failedProperty = unboxer.unbox("does.not.exist", isKeyPath: true)
-                
-                let formatter = NSDateFormatter()
-                formatter.dateFormat = "YYYY-MM-dd'T'HH:mm:ss"
-                self.registered = unboxer.unbox("registered", formatter: formatter)
+                self.successProperty = unboxer.unbox("success")
+                self.failedProperty = unboxer.unbox("notexist")
             }
         }
         
-        guard let data = JSONMockString.dataUsingEncoding(NSUTF8StringEncoding) else {
-            XCTFail("Could not create data from a string")
-            return
-        }
+        let array: [UnboxableDictionary] = [
+            [
+                "success" : "Hello"
+            ],
+            [
+                "success" : "Unbox"
+            ]
+        ]
         
-        guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
+        guard let items: [Model] = Unbox(array, allowInvalidElements: true) else {
             XCTFail("Could not unbox collections from data")
             return
         }
         
-        XCTAssert(items.count == 5, "Unbox did not return correct number of elements with invalid data")
+        XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
     }
 }
 
@@ -905,134 +892,6 @@ private struct UnboxTestSimpleMock: Unboxable, Equatable {
         self.int = unboxer.unbox("int")
     }
 }
-
-// Generated from: http://www.json-generator.com
-/*
-[
-  {
-    "id": "56fb5031affd22691ea32b92",
-    "name": "Clare Lancaster",
-    "isActive": true,
-    "age": 27,
-    "registered": "2014-07-14T07:04:50",
-    "tags": [
-      "magna",
-      "velit",
-      "qui",
-      "ea",
-      "fugiat",
-      "est",
-      "eiusmod"
-    ],
-    "meta": {
-      "link": {
-        "self": "http://example.com/ex",
-        "author": "http://example.com/exercitation",
-        "collection": "http://example.com/enim",
-        "replies": "http://example.com/fugiat"
-      }
-    }
-  },
-  {
-    "id": "56fb50316dacc51823381a99",
-    "name": "Angela Chan",
-    "isActive": true,
-    "age": 22,
-    "registered": "2016-02-09T04:09:05",
-    "tags": [
-      "sunt",
-      "et",
-      "commodo",
-      "in",
-      "nulla",
-      "id",
-      "sunt"
-    ],
-    "meta": {
-      "link": {
-        "self": "http://example.com/consectetur",
-        "author": "http://example.com/minim",
-        "collection": "http://example.com/sint",
-        "replies": "http://example.com/amet"
-      }
-    }
-  },
-  {
-    "id": "56fb50319138febd691cf0cc",
-    "name": "Duncan Oneill",
-    "isActive": true,
-    "age": 33,
-    "registered": "2014-11-15T02:09:24",
-    "tags": [
-      "fugiat",
-      "ea",
-      "mollit",
-      "culpa",
-      "laborum",
-      "reprehenderit",
-      "sit"
-    ],
-    "meta": {
-      "link": {
-        "self": "http://example.com/velit",
-        "author": "http://example.com/cillum",
-        "collection": "http://example.com/minim",
-        "replies": "http://example.com/cupidatat"
-      }
-    }
-  },
-  {
-    "id": "56fb503199c6c08c8afb0dad",
-    "name": "Burke Nolan",
-    "isActive": true,
-    "age": 40,
-    "registered": "2014-06-04T01:04:40",
-    "tags": [
-      "ullamco",
-      "ullamco",
-      "in",
-      "labore",
-      "sit",
-      "nulla",
-      "Lorem"
-    ],
-    "meta": {
-      "link": {
-        "self": "http://example.com/amet",
-        "author": "http://example.com/sunt",
-        "collection": "http://example.com/reprehenderit",
-        "replies": "http://example.com/commodo"
-      }
-    }
-  },
-  {
-    "id": "56fb503151f18f3ebb06b7e3",
-    "name": "Bruce Keith",
-    "isActive": false,
-    "age": 25,
-    "registered": "2015-07-22T11:05:09",
-    "tags": [
-      "ea",
-      "tempor",
-      "laboris",
-      "nostrud",
-      "magna",
-      "aute",
-      "magna"
-    ],
-    "meta": {
-      "link": {
-        "self": "http://example.com/non",
-        "author": "http://example.com/eiusmod",
-        "collection": "http://example.com/ad",
-        "replies": "http://example.com/eiusmod"
-      }
-    }
-  }
-]
-*/
-// Minified above then escaped quotes: http://www.httputility.net/json-minifier.aspx
-private let JSONMockString: String = "[{\"id\":\"56fb5031affd22691ea32b92\",\"name\":\"Clare Lancaster\",\"isActive\":true,\"age\":27,\"registered\":\"2014-07-14T07:04:50\",\"tags\":[\"magna\",\"velit\",\"qui\",\"ea\",\"fugiat\",\"est\",\"eiusmod\"],\"meta\":{\"link\":{\"self\":\"http://example.com/ex\",\"author\":\"http://example.com/exercitation\",\"collection\":\"http://example.com/enim\",\"replies\":\"http://example.com/fugiat\"}}},{\"id\":\"56fb50316dacc51823381a99\",\"name\":\"Angela Chan\",\"isActive\":true,\"age\":22,\"registered\":\"2016-02-09T04:09:05\",\"tags\":[\"sunt\",\"et\",\"commodo\",\"in\",\"nulla\",\"id\",\"sunt\"],\"meta\":{\"link\":{\"self\":\"http://example.com/consectetur\",\"author\":\"http://example.com/minim\",\"collection\":\"http://example.com/sint\",\"replies\":\"http://example.com/amet\"}}},{\"id\":\"56fb50319138febd691cf0cc\",\"name\":\"Duncan Oneill\",\"isActive\":true,\"age\":33,\"registered\":\"2014-11-15T02:09:24\",\"tags\":[\"fugiat\",\"ea\",\"mollit\",\"culpa\",\"laborum\",\"reprehenderit\",\"sit\"],\"meta\":{\"link\":{\"self\":\"http://example.com/velit\",\"author\":\"http://example.com/cillum\",\"collection\":\"http://example.com/minim\",\"replies\":\"http://example.com/cupidatat\"}}},{\"id\":\"56fb503199c6c08c8afb0dad\",\"name\":\"Burke Nolan\",\"isActive\":true,\"age\":40,\"registered\":\"2014-06-04T01:04:40\",\"tags\":[\"ullamco\",\"ullamco\",\"in\",\"labore\",\"sit\",\"nulla\",\"Lorem\"],\"meta\":{\"link\":{\"self\":\"http://example.com/amet\",\"author\":\"http://example.com/sunt\",\"collection\":\"http://example.com/reprehenderit\",\"replies\":\"http://example.com/commodo\"}}},{\"id\":\"56fb503151f18f3ebb06b7e3\",\"name\":\"Bruce Keith\",\"isActive\":false,\"age\":25,\"registered\":\"2015-07-22T11:05:09\",\"tags\":[\"ea\",\"tempor\",\"laboris\",\"nostrud\",\"magna\",\"aute\",\"magna\"],\"meta\":{\"link\":{\"self\":\"http://example.com/non\",\"author\":\"http://example.com/eiusmod\",\"collection\":\"http://example.com/ad\",\"replies\":\"http://example.com/eiusmod\"}}}]"
 
 private func ==(lhs: UnboxTestSimpleMock, rhs: UnboxTestSimpleMock) -> Bool {
     return lhs.int == rhs.int

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -572,6 +572,47 @@ class UnboxTests: XCTestCase {
             XCTFail("Unexpected error thrown: \(error)")
         }
     }
+    
+    func testUnboxWithAllowInvalidElements() {
+        struct Model: Unboxable {
+            let id: String
+            let name: String
+            let isActive: Bool
+            let age: Int
+            let registered: NSDate?
+            let tags: [String]
+            let authorLink: String
+            let repliesLink: String
+            let failedProperty: String
+            
+            init(unboxer: Unboxer) {
+                self.id = unboxer.unbox("id")
+                self.name = unboxer.unbox("name")
+                self.isActive = unboxer.unbox("isActive")
+                self.age = unboxer.unbox("age")
+                self.tags = unboxer.unbox("tags")
+                self.authorLink = unboxer.unbox("meta.link.author", isKeyPath: true)
+                self.repliesLink = unboxer.unbox("meta.link.replies", isKeyPath: true)
+                self.failedProperty = unboxer.unbox("does.not.exist", isKeyPath: true)
+                
+                let formatter = NSDateFormatter()
+                formatter.dateFormat = "YYYY-MM-dd'T'HH:mm:ss"
+                self.registered = unboxer.unbox("registered", formatter: formatter)
+            }
+        }
+        
+        guard let data = JSONMockString.dataUsingEncoding(NSUTF8StringEncoding) else {
+            XCTFail("Could not create data from a string")
+            return
+        }
+        
+        guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
+            XCTFail("Could not unbox collections from data")
+            return
+        }
+        
+        XCTAssert(items.count == 5, "Unbox did not return correct number of elements with invalid data")
+    }
 }
 
 private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool) -> UnboxableDictionary {
@@ -864,6 +905,134 @@ private struct UnboxTestSimpleMock: Unboxable, Equatable {
         self.int = unboxer.unbox("int")
     }
 }
+
+// Generated from: http://www.json-generator.com
+/*
+[
+  {
+    "id": "56fb5031affd22691ea32b92",
+    "name": "Clare Lancaster",
+    "isActive": true,
+    "age": 27,
+    "registered": "2014-07-14T07:04:50",
+    "tags": [
+      "magna",
+      "velit",
+      "qui",
+      "ea",
+      "fugiat",
+      "est",
+      "eiusmod"
+    ],
+    "meta": {
+      "link": {
+        "self": "http://example.com/ex",
+        "author": "http://example.com/exercitation",
+        "collection": "http://example.com/enim",
+        "replies": "http://example.com/fugiat"
+      }
+    }
+  },
+  {
+    "id": "56fb50316dacc51823381a99",
+    "name": "Angela Chan",
+    "isActive": true,
+    "age": 22,
+    "registered": "2016-02-09T04:09:05",
+    "tags": [
+      "sunt",
+      "et",
+      "commodo",
+      "in",
+      "nulla",
+      "id",
+      "sunt"
+    ],
+    "meta": {
+      "link": {
+        "self": "http://example.com/consectetur",
+        "author": "http://example.com/minim",
+        "collection": "http://example.com/sint",
+        "replies": "http://example.com/amet"
+      }
+    }
+  },
+  {
+    "id": "56fb50319138febd691cf0cc",
+    "name": "Duncan Oneill",
+    "isActive": true,
+    "age": 33,
+    "registered": "2014-11-15T02:09:24",
+    "tags": [
+      "fugiat",
+      "ea",
+      "mollit",
+      "culpa",
+      "laborum",
+      "reprehenderit",
+      "sit"
+    ],
+    "meta": {
+      "link": {
+        "self": "http://example.com/velit",
+        "author": "http://example.com/cillum",
+        "collection": "http://example.com/minim",
+        "replies": "http://example.com/cupidatat"
+      }
+    }
+  },
+  {
+    "id": "56fb503199c6c08c8afb0dad",
+    "name": "Burke Nolan",
+    "isActive": true,
+    "age": 40,
+    "registered": "2014-06-04T01:04:40",
+    "tags": [
+      "ullamco",
+      "ullamco",
+      "in",
+      "labore",
+      "sit",
+      "nulla",
+      "Lorem"
+    ],
+    "meta": {
+      "link": {
+        "self": "http://example.com/amet",
+        "author": "http://example.com/sunt",
+        "collection": "http://example.com/reprehenderit",
+        "replies": "http://example.com/commodo"
+      }
+    }
+  },
+  {
+    "id": "56fb503151f18f3ebb06b7e3",
+    "name": "Bruce Keith",
+    "isActive": false,
+    "age": 25,
+    "registered": "2015-07-22T11:05:09",
+    "tags": [
+      "ea",
+      "tempor",
+      "laboris",
+      "nostrud",
+      "magna",
+      "aute",
+      "magna"
+    ],
+    "meta": {
+      "link": {
+        "self": "http://example.com/non",
+        "author": "http://example.com/eiusmod",
+        "collection": "http://example.com/ad",
+        "replies": "http://example.com/eiusmod"
+      }
+    }
+  }
+]
+*/
+// Minified above then escaped quotes: http://www.httputility.net/json-minifier.aspx
+private let JSONMockString: String = "[{\"id\":\"56fb5031affd22691ea32b92\",\"name\":\"Clare Lancaster\",\"isActive\":true,\"age\":27,\"registered\":\"2014-07-14T07:04:50\",\"tags\":[\"magna\",\"velit\",\"qui\",\"ea\",\"fugiat\",\"est\",\"eiusmod\"],\"meta\":{\"link\":{\"self\":\"http://example.com/ex\",\"author\":\"http://example.com/exercitation\",\"collection\":\"http://example.com/enim\",\"replies\":\"http://example.com/fugiat\"}}},{\"id\":\"56fb50316dacc51823381a99\",\"name\":\"Angela Chan\",\"isActive\":true,\"age\":22,\"registered\":\"2016-02-09T04:09:05\",\"tags\":[\"sunt\",\"et\",\"commodo\",\"in\",\"nulla\",\"id\",\"sunt\"],\"meta\":{\"link\":{\"self\":\"http://example.com/consectetur\",\"author\":\"http://example.com/minim\",\"collection\":\"http://example.com/sint\",\"replies\":\"http://example.com/amet\"}}},{\"id\":\"56fb50319138febd691cf0cc\",\"name\":\"Duncan Oneill\",\"isActive\":true,\"age\":33,\"registered\":\"2014-11-15T02:09:24\",\"tags\":[\"fugiat\",\"ea\",\"mollit\",\"culpa\",\"laborum\",\"reprehenderit\",\"sit\"],\"meta\":{\"link\":{\"self\":\"http://example.com/velit\",\"author\":\"http://example.com/cillum\",\"collection\":\"http://example.com/minim\",\"replies\":\"http://example.com/cupidatat\"}}},{\"id\":\"56fb503199c6c08c8afb0dad\",\"name\":\"Burke Nolan\",\"isActive\":true,\"age\":40,\"registered\":\"2014-06-04T01:04:40\",\"tags\":[\"ullamco\",\"ullamco\",\"in\",\"labore\",\"sit\",\"nulla\",\"Lorem\"],\"meta\":{\"link\":{\"self\":\"http://example.com/amet\",\"author\":\"http://example.com/sunt\",\"collection\":\"http://example.com/reprehenderit\",\"replies\":\"http://example.com/commodo\"}}},{\"id\":\"56fb503151f18f3ebb06b7e3\",\"name\":\"Bruce Keith\",\"isActive\":false,\"age\":25,\"registered\":\"2015-07-22T11:05:09\",\"tags\":[\"ea\",\"tempor\",\"laboris\",\"nostrud\",\"magna\",\"aute\",\"magna\"],\"meta\":{\"link\":{\"self\":\"http://example.com/non\",\"author\":\"http://example.com/eiusmod\",\"collection\":\"http://example.com/ad\",\"replies\":\"http://example.com/eiusmod\"}}}]"
 
 private func ==(lhs: UnboxTestSimpleMock, rhs: UnboxTestSimpleMock) -> Bool {
     return lhs.int == rhs.int

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -573,57 +573,72 @@ class UnboxTests: XCTestCase {
         }
     }
     
-    func testUnboxDictionariesArrayWithObjectsWithFailableProperties() {
+    func testUnboxWithAllowInvalidElementsForDictionary() {
         struct Model: Unboxable {
-            let property1: String
-            let property2: String
+            let successProperty: String
+            let failedProperty: String
             
             init(unboxer: Unboxer) {
-                self.property1 = unboxer.unbox("notfailable1")
-                self.property2 = unboxer.unbox("notfailable2")
+                self.successProperty = unboxer.unbox("success")
+                self.failedProperty = unboxer.unbox("notexist")
             }
         }
         
         let array: [UnboxableDictionary] = [
             [
-                "notfailable1" : "Hello",
-                "notfailable2" : "Hello"
+                "success" : "Hello"
             ],
             [
-                "notfailable1" : "Hello"
+                "success" : "Unbox"
             ]
         ]
         
-        let items: [Model] = Unbox(array, allowInvalidElements: true) ?? []
-        XCTAssert(items.count == 1, "Unbox did not return correct number of valid elements")
+        guard let items: [Model] = Unbox(array, allowInvalidElements: true) else {
+            XCTFail("Could not unbox collections from data")
+            return
+        }
         
-        let items2: [Model]? = Unbox(array)
-        XCTAssert(items2 == nil, "Unbox should not return data")
+        XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
+        
+        guard let items2: [Model] = Unbox(array) else {
+            // Nil expected and correct
+            return
+        }
+        
+        XCTAssert(items2.count > 0, "Unbox should not have return data with invalid data for allowInvalidElements = false")
     }
     
-    func testUnboxDataArrayWithObjectsWithFailableProperties() {
+    func testUnboxWithAllowInvalidElementsForData() {
         struct Model: Unboxable {
-            let property1: String
-            let property2: String
+            let successProperty: String
+            let failedProperty: String
             
             init(unboxer: Unboxer) {
-                self.property1 = unboxer.unbox("notfailable1")
-                self.property2 = unboxer.unbox("notfailable2")
+                self.successProperty = unboxer.unbox("success")
+                self.failedProperty = unboxer.unbox("notexist")
             }
         }
         
-        let json = "[{\"notfailable1\":\"Hello\",\"notfailable2\":\"Hello\"},{\"notfailable1\":\"Hello\"}]"
+        let json = "[{\"success\":\"Hello\"},{\"success\":\"Unbox\"}]"
         
         guard let data = json.dataUsingEncoding(NSUTF8StringEncoding) else {
              XCTFail("Could not create data from a string")
              return
         }
         
-        let items: [Model] = Unbox(data, allowInvalidElements: true) ?? []
-        XCTAssert(items.count == 1, "Unbox did not return correct number of valid elements")
+        guard let items: [Model] = Unbox(data, allowInvalidElements: true) else {
+            XCTFail("Could not unbox collections from data")
+            return
+        }
         
-        let items2: [Model]? = Unbox(data)
-        XCTAssert(items2 == nil, "Unbox should not return data")
+        XCTAssert(items.count == 2, "Unbox did not return correct number of elements with invalid data")
+        
+        guard let items2: [Model] = Unbox(data) else {
+            // Nil expected and correct
+            return
+        }
+        
+        XCTAssert(items2.count > 0, "Unbox should not have return data with invalid data for allowInvalidElements = false")
     }
 }
 


### PR DESCRIPTION
Whether using `Unbox` or `UnboxOrThrow`, the current implementation nil's the object or returns an empty collection completely if there is a single property on a single object that is invalid. This is necessary when perfect data is needed.

However, this pull request adds an option to skip invalid data and move on to the next property or object. This way, the consuming developer can prefer to deal with default values instead of an empty collection or nil object.

Use as:
```
let items: [Post] = UnboxOrSkip(data)
```

Also part of discussion #39.