### PR TITLE
Move public API logic into Unboxer static private functions.

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -35,92 +35,84 @@ public typealias UnboxableDictionary = [String : AnyObject]
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) -> T? {
-    return try? UnboxOrThrow(dictionary, context: context)
+    return try? Unboxer.performUnboxingWithDictionary(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) -> [T]? {
-    return try? UnboxOrThrow(dictionaries, context: context)
+    return try? Unboxer.performUnboxingWithDictionaries(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> T? {
-    return try? UnboxOrThrow(data, context: context)
+    return try? Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) -> [T]? {
-    return try? UnboxOrThrow(data, context: context)
+    return try? Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) -> T? {
-    return try? UnboxOrThrow(dictionary, context: context)
+    return try? Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) -> [T]? {
-    return try? UnboxOrThrow(dictionaries, context: context)
+    return try? Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> T? {
-    return try? UnboxOrThrow(data, context: context)
+    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) -> [T]? {
-    return try? UnboxOrThrow(data, context: context)
+    return try? Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 // MARK: - Throwing Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-    return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
+    return try Unboxer.performUnboxingWithDictionary(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
-    return try dictionaries.map({
-        try UnboxOrThrow($0, context: context)
-    })
+    return try Unboxer.performUnboxingWithDictionaries(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-    return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    return try Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while optionally using a contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
-    return try Unboxer.unboxersFromData(data, context: context).map({
-        return try $0.performUnboxing()
-    })
+    return try Unboxer.performUnboxingWithData(data, context: context)
 }
 
 /// Unbox a JSON dictionary into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-    return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
+    return try Unboxer.performUnboxingWithDictionaryAndContext(dictionary, context: context)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
-    return try dictionaries.map({
-        try UnboxOrThrow($0, context: context)
-    })
+    return try Unboxer.performUnboxingWithDictionariesAndContext(dictionaries, context: context)
 }
 
 /// Unbox binary data into a model `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-    return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 /// Unbox binary data into an array of `T`, while using a required contextual object. Throws `UnboxError`.
 public func UnboxOrThrow<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
-    return try Unboxer.unboxersFromData(data, context: context).map({
-        return try $0.performUnboxingWithContext(context)
-    })
+    return try Unboxer.performUnboxingWithDataAndContext(data, context: context)
 }
 
 // MARK: - Error type
@@ -427,15 +419,15 @@ public class Unboxer {
     
     /// Unbox a required Array of enum raw values to an Array of enums using a transform
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> [T] {
-        return UnboxValueResolver<[T.RawValue]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: { (array) -> [T]? in
-            return array.flatMap({ T(rawValue: $0) })
+        return UnboxValueResolver<[T.RawValue]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: { array in
+            return array.flatMap { T(rawValue: $0) }
         })
     }
     
     /// Unbox an optional Array of enum raw values to an Array of enums using a transform
     public func unbox<T: UnboxableEnum>(key: String, isKeyPath: Bool = false) -> [T]? {
-        return UnboxValueResolver<[T.RawValue]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: { (array) -> [T]? in
-            return array.flatMap({ T(rawValue: $0) })
+        return UnboxValueResolver<[T.RawValue]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: { array in
+            return array.flatMap { T(rawValue: $0) }
         })
     }
     
@@ -672,6 +664,46 @@ private extension Unboxer {
             })
         } catch {
             throw UnboxError.InvalidData
+        }
+    }
+
+    static func performUnboxingWithDictionary<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
+    }
+
+    static func performUnboxingWithDictionaries<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil) throws -> [T] {
+        return try dictionaries.map {
+            try performUnboxingWithDictionary($0, context: context)
+        }
+    }
+
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+    }
+
+    static func performUnboxingWithData<T: Unboxable>(data: NSData, context: Any? = nil) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context).map {
+            return try $0.performUnboxing()
+        }
+    }
+
+    static func performUnboxingWithDictionaryAndContext<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
+        return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
+    }
+
+    static func performUnboxingWithDictionariesAndContext<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType) throws -> [T] {
+        return try dictionaries.map {
+            try performUnboxingWithDictionaryAndContext($0, context: context)
+        }
+    }
+
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
+        return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+    }
+
+    static func performUnboxingWithDataAndContext<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> [T] {
+        return try Unboxer.unboxersFromData(data, context: context).map {
+            return try $0.performUnboxingWithContext(context)
         }
     }
     


### PR DESCRIPTION
To isolate issues and avoid confusion with #41, here's a fresh pull request that just moves the public function logic into `Unboxer`. #41 will rebase once this PR is complete.