### PR TITLE
Skip invalid data instead of exiting completely v3

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -38,7 +38,7 @@ public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? =
     return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
 }
 
-/// Unbox an array of JSON dictionaries into an array of `T`, optionally using a contextual object. Throws `UnboxError`.
+/// Unbox an array of JSON dictionaries into an array of `T`, optionally using a contextual object and/or invalid elements. Throws `UnboxError`.
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
     return try dictionaries.mapAllowingInvalidElements(allowInvalidElements, transform: {
         try Unbox($0, context: context)
@@ -50,7 +50,7 @@ public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
     return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
 }
 
-/// Unbox binary data into an array of `T`, optionally using a contextual object. Throws `UnboxError`.
+/// Unbox binary data into an array of `T`, optionally using a contextual object and/or invalid elements. Throws `UnboxError`.
 public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
     return try Unboxer.unboxersFromData(data, context: context).mapAllowingInvalidElements(allowInvalidElements, transform: {
         return try $0.performUnboxing()
@@ -62,7 +62,7 @@ public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, cont
     return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
 }
 
-/// Unbox an array of JSON dictionaries into an array of `T` using a required contextual object. Throws `UnboxError`.
+/// Unbox an array of JSON dictionaries into an array of `T` using a required contextual object and/or invalid elements. Throws `UnboxError`.
 public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
     return try dictionaries.mapAllowingInvalidElements(allowInvalidElements, transform: {
         try Unbox($0, context: context)
@@ -74,7 +74,7 @@ public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType)
     return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
 }
 
-/// Unbox binary data into an array of `T` using a required contextual object. Throws `UnboxError`.
+/// Unbox binary data into an array of `T` using a required contextual object and/or invalid elements. Throws `UnboxError`.
 public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
     return try Unboxer.unboxersFromData(data, context: context).mapAllowingInvalidElements(allowInvalidElements, transform: {
         return try $0.performUnboxingWithContext(context)
@@ -411,14 +411,14 @@ public class Unboxer {
         })
     }
     
-    /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
+    /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
             return try? Unbox($0, context: self.context, allowInvalidElements: allowInvalidElements)
         })
     }
     
-    /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
+    /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
     public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return try? Unbox($0, context: self.context, allowInvalidElements: allowInvalidElements)
@@ -453,14 +453,14 @@ public class Unboxer {
         })
     }
     
-    /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
+    /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, allowInvalidElements: Bool = false) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
             return try? Unbox($0, context: context, allowInvalidElements: allowInvalidElements)
         })
     }
     
-    /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
+    /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
     public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
             return try? Unbox($0, context: context, allowInvalidElements: allowInvalidElements)

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -412,16 +412,16 @@ public class Unboxer {
     }
     
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
-    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> [T] {
+    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
-            return try? Unbox($0, context: self.context)
+            return try? Unbox($0, context: self.context, allowInvalidElements: allowInvalidElements)
         })
     }
     
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform
-    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false) -> [T]? {
+    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
-            return try? Unbox($0, context: self.context)
+            return try? Unbox($0, context: self.context, allowInvalidElements: allowInvalidElements)
         })
     }
     
@@ -454,16 +454,16 @@ public class Unboxer {
     }
     
     /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
-    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> [T] {
+    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, allowInvalidElements: Bool = false) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
-            return try? Unbox($0, context: context)
+            return try? Unbox($0, context: context, allowInvalidElements: allowInvalidElements)
         })
     }
     
     /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform
-    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType) -> [T]? {
+    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
-            return try? Unbox($0, context: context)
+            return try? Unbox($0, context: context, allowInvalidElements: allowInvalidElements)
         })
     }
     

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -298,6 +298,30 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testUnboxingArrayOfDictionariesWhileAllowingInvalidElements() {
+        struct Model: Unboxable {
+            let string: String
+            
+            init(unboxer: Unboxer) {
+                self.string = unboxer.unbox("string")
+            }
+        }
+        
+        let dictionaries: [UnboxableDictionary] = [
+            ["string" : "one"],
+            ["invalid" : "element"],
+            ["string" : "two"]
+        ]
+        
+        do {
+            let unboxed: [Model] = try Unbox(dictionaries, allowInvalidElements: true)
+            XCTAssertEqual(unboxed.first?.string, "one")
+            XCTAssertEqual(unboxed.last?.string, "two")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
     func testThrowingForMissingRequiredValues() {
         let validDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
         

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -322,6 +322,40 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testUnboxingNestedArrayOfDictionariesWhileAllowingInvalidElements() {
+        struct Model: Unboxable {
+            let nestedModels: [NestedModel]
+            
+            init(unboxer: Unboxer) {
+                self.nestedModels = unboxer.unbox("nested", allowInvalidElements: true)
+            }
+        }
+        
+        struct NestedModel: Unboxable {
+            let string: String
+            
+            init(unboxer: Unboxer) {
+                self.string = unboxer.unbox("string")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "nested" : [
+                ["string" : "one"],
+                ["invalid" : "element"],
+                ["string" : "two"]
+            ]
+        ]
+        
+        do {
+            let unboxed: Model = try Unbox(dictionary)
+            XCTAssertEqual(unboxed.nestedModels.first?.string, "one")
+            XCTAssertEqual(unboxed.nestedModels.last?.string, "two")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
     func testThrowingForMissingRequiredValues() {
         let validDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
         


### PR DESCRIPTION
Implement support for partial unboxing of arrays of dictionaries - using a `allowInvalidElements` parameter (that defaults to `false`). If the parameter is set to `true`, Unbox will skip invalid elements instead of returning a `nil` array or causing the unboxing process to fail.

Huge thanks to @acecilia & @basememara for their original implementations! 🎉 🚀  