### PR TITLE
Support nested collections of any type

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -317,13 +317,13 @@ public class Unboxer {
         return UnboxValueResolver<T>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath)
     }
     
-    /// Unbox a required Array of raw values
-    public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [T] {
+    /// Unbox a required Array
+    public func unbox<T>(key: String, isKeyPath: Bool = false) -> [T] {
         return UnboxValueResolver<[T]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [])
     }
     
-    /// Unbox an optional Array of raw values
-    public func unbox<T: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [T]? {
+    /// Unbox an optional Array
+    public func unbox<T>(key: String, isKeyPath: Bool = false) -> [T]? {
         return UnboxValueResolver<[T]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath)
     }
     
@@ -349,23 +349,13 @@ public class Unboxer {
         })
     }
     
-    /// Unbox a required Dictionary with untyped values, without applying a transform on them
-    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K : AnyObject] {
-        return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: { $0 }) ?? [:]
-    }
-    
-    /// Unbox an optional Dictionary with untyped values, without applying a transform on them
-    public func unbox<K: UnboxableKey>(key: String, isKeyPath: Bool = false) -> [K : AnyObject]? {
-        return UnboxValueResolver<[String : AnyObject]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: { $0 })
-    }
-    
-    /// Unbox a required Dictionary with raw values
-    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K : V] {
+    /// Unbox a required Dictionary
+    public func unbox<K: UnboxableKey, V>(key: String, isKeyPath: Bool = false) -> [K : V] {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, valueTransform: { $0 }) ?? [:]
     }
     
-    /// Unbox an optional Dictionary with raw values
-    public func unbox<K: UnboxableKey, V: UnboxableRawType>(key: String, isKeyPath: Bool = false) -> [K : V]? {
+    /// Unbox an optional Dictionary
+    public func unbox<K: UnboxableKey, V>(key: String, isKeyPath: Bool = false) -> [K : V]? {
         return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, valueTransform: { $0 })
     }
     

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -356,6 +356,64 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testNestedArray() {
+        struct Model: Unboxable {
+            let arrays: [[Int]]
+            
+            init(unboxer: Unboxer) {
+                self.arrays = unboxer.unbox("arrays")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "arrays": [
+                [1, 2],
+                [3, 4]
+            ]
+        ]
+        
+        do {
+            let unboxed: Model = try Unbox(dictionary)
+            XCTAssertEqual(unboxed.arrays.count, 2)
+            XCTAssertEqual(unboxed.arrays.first!, [1, 2])
+            XCTAssertEqual(unboxed.arrays.last!, [3, 4])
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testNestedDictionary() {
+        struct Model: Unboxable {
+            let dictionaries: [String : [String : Int]]
+            
+            init(unboxer: Unboxer) {
+                self.dictionaries = unboxer.unbox("dictionaries")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "dictionaries" : [
+                "one" : [
+                    "a" : 1,
+                    "b" : 2
+                ],
+                "two" : [
+                    "c" : 3,
+                    "d" : 4
+                ]
+            ]
+        ]
+        
+        do {
+            let unboxed: Model = try Unbox(dictionary)
+            XCTAssertEqual(unboxed.dictionaries.count, 2)
+            XCTAssertEqual(unboxed.dictionaries["one"]!, ["a" : 1, "b" : 2])
+            XCTAssertEqual(unboxed.dictionaries["two"]!, ["c" : 3, "d" : 4])
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
     func testThrowingForMissingRequiredValues() {
         let validDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
         


### PR DESCRIPTION
This change makes Unbox support nested collections (arrays & dictionaries) of any type, rather than being constrained to raw values and transformed types. While this theoretically enables decoding code to be written using invalid JSON types - the extra level of flexibility is worth it.

Fixes https://github.com/JohnSundell/Unbox/issues/34