### PR TITLE
Replaced allow invalid elements to threshold acceptance.

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -34,51 +34,58 @@ public typealias UnboxableDictionary = [String : AnyObject]
 // MARK: - Unbox functions
 
 /// Unbox a JSON dictionary into a model `T`, optionally using a contextual object. Throws `UnboxError`.
-public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil) throws -> T {
-    return try Unboxer(dictionary: dictionary, context: context).performUnboxing()
+public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, context: Any? = nil, threshold: UnboxThreshold = .ThrowError) throws -> T {
+    return try Unboxer(dictionary: dictionary, context: context).performUnboxing(threshold)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T`, optionally using a contextual object and/or invalid elements. Throws `UnboxError`.
-public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-    return try dictionaries.mapAllowingInvalidElements(allowInvalidElements, transform: {
-        try Unbox($0, context: context)
+public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, threshold: UnboxThreshold = .ThrowError) throws -> [T] {
+    return try dictionaries.mapElementsWithThreshold(threshold, transform: {
+        try Unbox($0, context: context, threshold: threshold)
     })
 }
 
 /// Unbox binary data into a model `T`, optionally using a contextual object. Throws `UnboxError`.
-public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil) throws -> T {
-    return try Unboxer.unboxerFromData(data, context: context).performUnboxing()
+public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, threshold: UnboxThreshold = .ThrowError) throws -> T {
+    return try Unboxer.unboxerFromData(data, context: context).performUnboxing(threshold)
 }
 
 /// Unbox binary data into an array of `T`, optionally using a contextual object and/or invalid elements. Throws `UnboxError`.
-public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
-    return try Unboxer.unboxersFromData(data, context: context).mapAllowingInvalidElements(allowInvalidElements, transform: {
-        return try $0.performUnboxing()
+public func Unbox<T: Unboxable>(data: NSData, context: Any? = nil, threshold: UnboxThreshold = .ThrowError) throws -> [T] {
+    return try Unboxer.unboxersFromData(data, context: context).mapElementsWithThreshold(threshold, transform: {
+        return try $0.performUnboxing(threshold)
     })
 }
 
 /// Unbox a JSON dictionary into a model `T` using a required contextual object. Throws `UnboxError`.
-public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType) throws -> T {
-    return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context)
+public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, context: T.ContextType, threshold: UnboxThreshold = .ThrowError) throws -> T {
+    return try Unboxer(dictionary: dictionary, context: context).performUnboxingWithContext(context, threshold: threshold)
 }
 
 /// Unbox an array of JSON dictionaries into an array of `T` using a required contextual object and/or invalid elements. Throws `UnboxError`.
-public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-    return try dictionaries.mapAllowingInvalidElements(allowInvalidElements, transform: {
-        try Unbox($0, context: context)
+public func Unbox<T: UnboxableWithContext>(dictionaries: [UnboxableDictionary], context: T.ContextType, threshold: UnboxThreshold = .ThrowError) throws -> [T] {
+    return try dictionaries.mapElementsWithThreshold(threshold, transform: {
+        try Unbox($0, context: context, threshold: threshold)
     })
 }
 
 /// Unbox binary data into a model `T` using a required contextual object. Throws `UnboxError`.
-public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType) throws -> T {
-    return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context)
+public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, threshold: UnboxThreshold = .ThrowError) throws -> T {
+    return try Unboxer.unboxerFromData(data, context: context).performUnboxingWithContext(context, threshold: threshold)
 }
 
 /// Unbox binary data into an array of `T` using a required contextual object and/or invalid elements. Throws `UnboxError`.
-public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, allowInvalidElements: Bool = false) throws -> [T] {
-    return try Unboxer.unboxersFromData(data, context: context).mapAllowingInvalidElements(allowInvalidElements, transform: {
-        return try $0.performUnboxingWithContext(context)
+public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType, threshold: UnboxThreshold = .ThrowError) throws -> [T] {
+    return try Unboxer.unboxersFromData(data, context: context).mapElementsWithThreshold(threshold, transform: {
+        return try $0.performUnboxingWithContext(context, threshold: threshold)
     })
+}
+
+// MARK: - Enums
+public enum UnboxThreshold {
+    case ThrowError
+    case SkipInvalid
+    case AllowInvalid
 }
 
 // MARK: - Error type
@@ -351,12 +358,12 @@ public class Unboxer {
     
     /// Unbox a required Dictionary
     public func unbox<K: UnboxableKey, V>(key: String, isKeyPath: Bool = false) -> [K : V] {
-        return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, allowInvalidElements: false, valueTransform: { $0 }) ?? [:]
+        return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, threshold: .ThrowError, valueTransform: { $0 }) ?? [:]
     }
     
     /// Unbox an optional Dictionary
     public func unbox<K: UnboxableKey, V>(key: String, isKeyPath: Bool = false) -> [K : V]? {
-        return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, allowInvalidElements: false, valueTransform: { $0 })
+        return UnboxValueResolver<[String : V]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, threshold: .ThrowError, valueTransform: { $0 })
     }
     
     /// Unbox a required enum value
@@ -402,30 +409,30 @@ public class Unboxer {
     }
     
     /// Unbox a required Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
-    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [T] {
+    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, threshold: UnboxThreshold = .ThrowError) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
-            return try? Unbox($0, context: self.context, allowInvalidElements: allowInvalidElements)
+            return try? Unbox($0, context: self.context, threshold: threshold)
         })
     }
     
     /// Unbox an optional Array of nested Unboxables, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
-    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [T]? {
+    public func unbox<T: Unboxable>(key: String, isKeyPath: Bool = false, threshold: UnboxThreshold = .ThrowError) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
-            return try? Unbox($0, context: self.context, allowInvalidElements: allowInvalidElements)
+            return try? Unbox($0, context: self.context, threshold: threshold)
         })
     }
     
     /// Unbox a required Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [K : V] {
-        return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, allowInvalidElements: allowInvalidElements, valueTransform: {
-            return try? Unbox($0, context: self.context)
+    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false, threshold: UnboxThreshold = .ThrowError) -> [K : V] {
+        return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: true, threshold: threshold, valueTransform: {
+            return try? Unbox($0, context: self.context, threshold: threshold)
         }) ?? [:]
     }
     
     /// Unbox an optional Dictionary of nested Unboxables, by unboxing an Dictionary of Dictionaries and then using a transform
-    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false, allowInvalidElements: Bool = false) -> [K : V]? {
-        return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, allowInvalidElements: allowInvalidElements, valueTransform: {
-            return try? Unbox($0, context: self.context)
+    public func unbox<K: UnboxableKey, V: Unboxable>(key: String, isKeyPath: Bool = false, threshold: UnboxThreshold = .ThrowError) -> [K : V]? {
+        return UnboxValueResolver<[String : UnboxableDictionary]>(self).resolveDictionaryValuesForKey(key, isKeyPath: isKeyPath, required: false, threshold: threshold, valueTransform: {
+            return try? Unbox($0, context: self.context, threshold: threshold)
         })
     }
     
@@ -444,16 +451,16 @@ public class Unboxer {
     }
     
     /// Unbox a required Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
-    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, allowInvalidElements: Bool = false) -> [T] {
+    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, threshold: UnboxThreshold = .ThrowError) -> [T] {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: {
-            return try? Unbox($0, context: context, allowInvalidElements: allowInvalidElements)
+            return try? Unbox($0, context: context, threshold: threshold)
         })
     }
     
     /// Unbox an optional Array of nested UnboxableWithContext types, by unboxing an Array of Dictionaries and then using a transform (optionally allowing invalid elements)
-    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, allowInvalidElements: Bool = false) -> [T]? {
+    public func unbox<T: UnboxableWithContext>(key: String, isKeyPath: Bool = false, context: T.ContextType, threshold: UnboxThreshold = .ThrowError) -> [T]? {
         return UnboxValueResolver<[UnboxableDictionary]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: {
-            return try? Unbox($0, context: context, allowInvalidElements: allowInvalidElements)
+            return try? Unbox($0, context: context, threshold: threshold)
         })
     }
     
@@ -557,7 +564,7 @@ private class UnboxValueResolver<T> {
 }
 
 extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConvertible, T.Key == String, T.Generator == DictionaryGenerator<T.Key, T.Value> {
-    func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, isKeyPath: Bool, required: Bool, allowInvalidElements: Bool, valueTransform: T.Value -> V?) -> [K : V]? {
+    func resolveDictionaryValuesForKey<K: UnboxableKey, V>(key: String, isKeyPath: Bool, required: Bool, threshold: UnboxThreshold, valueTransform: T.Value -> V?) -> [K : V]? {
         if let unboxedDictionary = self.resolveOptionalValueForKey(key, isKeyPath: isKeyPath) {
             var transformedDictionary = [K : V]()
             
@@ -569,7 +576,7 @@ extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConver
                     if let transformedValue = transformedValue {
                         transformedDictionary[transformedKey] = transformedValue
                         continue
-                    } else if allowInvalidElements {
+                    } else if threshold != .ThrowError {
                         continue
                     }
                 }
@@ -631,15 +638,23 @@ private extension Unboxer {
         }
     }
     
-    func performUnboxing<T: Unboxable>() throws -> T {
+    func performUnboxing<T: Unboxable>(threshold: UnboxThreshold = .ThrowError) throws -> T {
         let unboxed = T(unboxer: self)
-        try self.throwIfFailed()
+        
+        if threshold == .ThrowError || threshold == .SkipInvalid {
+            try self.throwIfFailed()
+        }
+        
         return unboxed
     }
     
-    func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType) throws -> T {
+    func performUnboxingWithContext<T: UnboxableWithContext>(context: T.ContextType, threshold: UnboxThreshold = .ThrowError) throws -> T {
         let unboxed = T(unboxer: self, context: context)
-        try self.throwIfFailed()
+        
+        if threshold == .ThrowError || threshold == .SkipInvalid {
+            try self.throwIfFailed()
+        }
+        
         return unboxed
     }
     
@@ -667,7 +682,7 @@ private extension Unboxer {
 }
 
 private extension Array {
-    func mapAllowingInvalidElements<T>(allowInvalidElements: Bool, transform: Element throws -> T) throws -> [T] {
+    func mapElementsWithThreshold<T>(threshold: UnboxThreshold, transform: Element throws -> T) throws -> [T] {
         var transformedArray = [T]()
         
         for element in self {
@@ -675,7 +690,7 @@ private extension Array {
                 let transformed = try transform(element)
                 transformedArray.append(transformed)
             } catch {
-                if !allowInvalidElements {
+                if threshold == .ThrowError {
                     throw error
                 }
             }

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -298,6 +298,31 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testUnboxingArrayOfDictionariesWhileSkippingInvalidElements() {
+        struct Model: Unboxable {
+            let string: String
+            
+            init(unboxer: Unboxer) {
+                self.string = unboxer.unbox("string")
+            }
+        }
+        
+        let dictionaries: [UnboxableDictionary] = [
+            ["string" : "one"],
+            ["invalid" : "element"],
+            ["string" : "two"]
+        ]
+        
+        do {
+            let unboxed: [Model] = try Unbox(dictionaries, threshold: .SkipInvalid)
+            XCTAssertEqual(unboxed.count, 2)
+            XCTAssertEqual(unboxed.first?.string, "one")
+            XCTAssertEqual(unboxed.last?.string, "two")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
     func testUnboxingArrayOfDictionariesWhileAllowingInvalidElements() {
         struct Model: Unboxable {
             let string: String
@@ -314,7 +339,8 @@ class UnboxTests: XCTestCase {
         ]
         
         do {
-            let unboxed: [Model] = try Unbox(dictionaries, allowInvalidElements: true)
+            let unboxed: [Model] = try Unbox(dictionaries, threshold: .AllowInvalid)
+            XCTAssertEqual(unboxed.count, 3)
             XCTAssertEqual(unboxed.first?.string, "one")
             XCTAssertEqual(unboxed.last?.string, "two")
         } catch {
@@ -322,12 +348,12 @@ class UnboxTests: XCTestCase {
         }
     }
     
-    func testUnboxingNestedArrayOfDictionariesWhileAllowingInvalidElements() {
+    func testUnboxingNestedArrayOfDictionariesWhileSkippingInvalidElements() {
         struct Model: Unboxable {
             let nestedModels: [NestedModel]
             
             init(unboxer: Unboxer) {
-                self.nestedModels = unboxer.unbox("nested", allowInvalidElements: true)
+                self.nestedModels = unboxer.unbox("nested", threshold: .SkipInvalid)
             }
         }
         
@@ -349,6 +375,7 @@ class UnboxTests: XCTestCase {
         
         do {
             let unboxed: Model = try Unbox(dictionary)
+            XCTAssertEqual(unboxed.nestedModels.count, 2)
             XCTAssertEqual(unboxed.nestedModels.first?.string, "one")
             XCTAssertEqual(unboxed.nestedModels.last?.string, "two")
         } catch {
@@ -356,12 +383,47 @@ class UnboxTests: XCTestCase {
         }
     }
     
-    func testUnboxingNestedDictionaryWhileAllowingInvalidElements() {
+    func testUnboxingNestedArrayOfDictionariesWhileAllowingInvalidElements() {
+        struct Model: Unboxable {
+            let nestedModels: [NestedModel]
+            
+            init(unboxer: Unboxer) {
+                self.nestedModels = unboxer.unbox("nested", threshold: .AllowInvalid)
+            }
+        }
+        
+        struct NestedModel: Unboxable {
+            let string: String
+            
+            init(unboxer: Unboxer) {
+                self.string = unboxer.unbox("string")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "nested" : [
+                ["string" : "one"],
+                ["invalid" : "element"],
+                ["string" : "two"]
+            ]
+        ]
+        
+        do {
+            let unboxed: Model = try Unbox(dictionary)
+            XCTAssertEqual(unboxed.nestedModels.count, 3)
+            XCTAssertEqual(unboxed.nestedModels.first?.string, "one")
+            XCTAssertEqual(unboxed.nestedModels.last?.string, "two")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testUnboxingNestedDictionaryWhileSkippingInvalidElements() {
         struct Model: Unboxable {
             let nestedModels: [String : NestedModel]
             
             init(unboxer: Unboxer) {
-                self.nestedModels = unboxer.unbox("nested", allowInvalidElements: true)
+                self.nestedModels = unboxer.unbox("nested", threshold: .SkipInvalid)
             }
         }
         
@@ -384,6 +446,41 @@ class UnboxTests: XCTestCase {
         do {
             let unboxed: Model = try Unbox(dictionary)
             XCTAssertEqual(unboxed.nestedModels.count, 2)
+            XCTAssertEqual(unboxed.nestedModels["one"]?.string, "one")
+            XCTAssertEqual(unboxed.nestedModels["three"]?.string, "two")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testUnboxingNestedDictionaryWhileAllowingInvalidElements() {
+        struct Model: Unboxable {
+            let nestedModels: [String : NestedModel]
+            
+            init(unboxer: Unboxer) {
+                self.nestedModels = unboxer.unbox("nested", threshold: .AllowInvalid)
+            }
+        }
+        
+        struct NestedModel: Unboxable {
+            let string: String
+            
+            init(unboxer: Unboxer) {
+                self.string = unboxer.unbox("string")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "nested" : [
+                "one" : ["string" : "one"],
+                "two" : ["invalid" : "element"],
+                "three" : ["string" : "two"]
+            ]
+        ]
+        
+        do {
+            let unboxed: Model = try Unbox(dictionary)
+            XCTAssertEqual(unboxed.nestedModels.count, 3)
             XCTAssertEqual(unboxed.nestedModels["one"]?.string, "one")
             XCTAssertEqual(unboxed.nestedModels["three"]?.string, "two")
         } catch {


### PR DESCRIPTION
Hey @JohnSundell and @acecilia, I hope you guys don't hate me for this :). The recently implemented `allowInvalidElements` works well. However, it works more like `skipInvalidElements`. When retrieving an array, if a single property fails then the whole element is skipped and the array continues.

I am proposing an extra option beyond this, if a single property fails then it should skip that property and allow the element to be added with a nil or empty _property_.

To this end, there should be a threshold introduced:
```
public enum UnboxThreshold {
    case ThrowError
    case SkipInvalid
    case AllowInvalid
}
```
The default is `ThrowError`. The `SkipInvalid` skips elements that fail on any property unboxing. The `AllowInvalid` skips the property of the element but continues to add the rest of the properties for the element.

You would use it like this:
```
let items: [Model] = try? Unbox(data)
let items: [Model] = try? Unbox(data, threshold: .ThrowError)
let items: [Model] = try? Unbox(data, threshold: .SkipInvalid)
let items: [Model] = try? Unbox(data, threshold: .AllowInvalid)
```
A use case is retrieving blog posts from a WordPress JSON endpoint. If it does not contain a featured image with different sizes, those nodes would be absent in the JSON. In the app though, I'd replace those with placeholder images instead of leaving those posts out of the app completely.