### PR TITLE
Add support for key path access with array index

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -529,6 +529,7 @@ private class UnboxValueResolver<T> {
     
     func resolveOptionalValueForKey<R>(key: String, isKeyPath: Bool, transform: T -> R?) -> R? {
         var dictionary = self.unboxer.dictionary
+        var array: [AnyObject]?
         var modifiedKey = key
 
         if isKeyPath && key.containsString(".") {
@@ -540,6 +541,10 @@ private class UnboxValueResolver<T> {
                     modifiedKey = keyPathComponent
                 } else if let nestedDictionary = dictionary[keyPathComponent] as? UnboxableDictionary {
                     dictionary = nestedDictionary
+                } else if let nestedArray = dictionary[keyPathComponent] as? [AnyObject] {
+                    array = nestedArray
+                } else if let array = array, let index = Int(keyPathComponent) where index < array.count {
+                    dictionary = array[index] as! UnboxableDictionary
                 } else {
                     return nil
                 }
@@ -547,6 +552,10 @@ private class UnboxValueResolver<T> {
         }
 
         if let value = dictionary[modifiedKey] as? T {
+            if let transformed = transform(value) {
+                return transformed
+            }
+        } else if let index = Int(modifiedKey), let array = array, let value = array[index] as? T {
             if let transformed = transform(value) {
                 return transformed
             }

--- a/Unbox.swift
+++ b/Unbox.swift
@@ -543,8 +543,8 @@ private class UnboxValueResolver<T> {
                     dictionary = nestedDictionary
                 } else if let nestedArray = dictionary[keyPathComponent] as? [AnyObject] {
                     array = nestedArray
-                } else if let array = array, let index = Int(keyPathComponent) where index < array.count {
-                    dictionary = array[index] as! UnboxableDictionary
+                } else if let array = array, let index = Int(keyPathComponent) where index < array.count, let nestedDictionary = array[index] as? UnboxableDictionary {
+                    dictionary = nestedDictionary
                 } else {
                     return nil
                 }

--- a/UnboxTests.swift
+++ b/UnboxTests.swift
@@ -609,6 +609,43 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testAccessingNestedArrayWithKeyPath() {
+        struct KeyPathModel: Unboxable {
+            let requiredArray: [String]
+            let dictionary: UnboxableDictionary
+            
+            init(unboxer: Unboxer) {
+                let elementKeyPathComponentsFirst = [UnboxTestMock.requiredUnboxableArrayKey, "0", UnboxTestMock.requiredArrayKey, "0"].joinWithSeparator(".")
+                let elementKeyPathComponentsSecond = [UnboxTestMock.requiredUnboxableArrayKey, "0", UnboxTestMock.requiredArrayKey, "1"].joinWithSeparator(".")
+                let elementKeyPathComponentsThird = [UnboxTestMock.requiredUnboxableArrayKey, "0", UnboxTestMock.requiredArrayKey, "2"].joinWithSeparator(".")
+                let elementKeyPathComponentsFourth = [UnboxTestMock.requiredUnboxableArrayKey, "0", UnboxTestMock.requiredArrayKey, "3"].joinWithSeparator(".")
+                let elementKeyPathComponentsFifth = [UnboxTestMock.requiredUnboxableArrayKey, "0", UnboxTestMock.requiredArrayKey, "4"].joinWithSeparator(".")
+                
+                let firstElement: String = unboxer.unbox(elementKeyPathComponentsFirst, isKeyPath: true)
+                let secondElement: String = unboxer.unbox(elementKeyPathComponentsSecond, isKeyPath: true)
+                let thirdElement: String = unboxer.unbox(elementKeyPathComponentsThird, isKeyPath: true)
+                let fourthElement: String = unboxer.unbox(elementKeyPathComponentsFourth, isKeyPath: true)
+                let fifthElement: String = unboxer.unbox(elementKeyPathComponentsFifth, isKeyPath: true)
+                requiredArray = [firstElement, secondElement, thirdElement, fourthElement, fifthElement]
+                
+                let dictionaryKeyPath = [UnboxTestMock.requiredUnboxableDictionaryKey, "test"].joinWithSeparator(".")
+                self.dictionary = unboxer.unbox(dictionaryKeyPath, isKeyPath: true)
+            }
+        }
+        
+        let validDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(false)
+        let model: KeyPathModel? = try? Unbox(validDictionary)
+        
+        XCTAssertNotNil(model)
+        
+        if let result = model?.dictionary[UnboxTestMock.requiredArrayKey] as? [String], let array = model?.requiredArray {
+            XCTAssertEqual(["unbox", "is", "pretty", "cool", "right?"], result)
+            XCTAssertEqual(result, array)
+        } else {
+            XCTFail()
+        }
+    }
+    
     func testKeysWithDotNotTreatedAsKeyPath() {
         struct Model: Unboxable {
             let int: Int


### PR DESCRIPTION
Hey John!
I just added support for key path access via index. It works like this:
```json
{
    "name": "John",
    "age": 27,
    "activities": [
        "running",
        "cycling"
        ]
    }
}
```

```swift
struct User: Unboxable {
    let name: String
    let age: Int
    let firstActivity: String

    init(unboxer: Unboxer) {
        self.name = unboxer.unbox("name")
        self.age = unboxer.unbox("age")
        self.firstActivity = unboxer.unbox("activities.1", isKeyPath: true)
    }
}
```
I also added a new test. I wanted to fully test how it works. I basically get all the elements in the array and build a new array out of the elements unwrapped by accessing the index key path. I then compare the new array to see if it's equal to the one accessed by normal subscripting. I don't know if its fits the rest of the tests suits, please let me know if you would prefer another approach to testing this feature! 👍 

Thanks again for the amazing project 🚀 