### PR TITLE
Made custom unboxing closures throw

### DIFF
--- a/Unbox.swift
+++ b/Unbox.swift
@@ -315,12 +315,12 @@ public class Unboxer {
     // MARK: - Custom unboxing API
     
     /// Perform custom unboxing using an Unboxer (created from a dictionary) passed to a closure, or throw an UnboxError
-    public static func performCustomUnboxingWithDictionary<T>(dictionary: UnboxableDictionary, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
+    public static func performCustomUnboxingWithDictionary<T>(dictionary: UnboxableDictionary, context: Any? = nil, closure: Unboxer throws -> T?) throws -> T {
         return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure)
     }
     
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, or throw an UnboxError
-    public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer -> T?) throws -> [T] {
+    public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) throws -> [T] {
         var unboxedArray = [T]()
         
         for dictionary in array {
@@ -332,7 +332,7 @@ public class Unboxer {
     }
     
     /// Perform custom unboxing using an Unboxer (created from NSData) passed to a closure, or throw an UnboxError
-    public static func performCustomUnboxingWithData<T>(data: NSData, context: Any? = nil, closure: Unboxer -> T?) throws -> T {
+    public static func performCustomUnboxingWithData<T>(data: NSData, context: Any? = nil, closure: Unboxer throws -> T?) throws -> T {
         return try Unboxer.unboxerFromData(data, context: context).performCustomUnboxingWithClosure(closure)
     }
     
@@ -695,8 +695,8 @@ private extension Unboxer {
         return unboxed
     }
     
-    func performCustomUnboxingWithClosure<T>(closure: Unboxer -> T?) throws -> T {
-        guard let unboxed: T = closure(self) else {
+    func performCustomUnboxingWithClosure<T>(closure: Unboxer throws -> T?) throws -> T {
+        guard let unboxed: T = try closure(self) else {
             throw UnboxError.CustomUnboxingFailed
         }
         


### PR DESCRIPTION
Consider this JSON

```json
{
  "animals": [
    { "type": "cat", "name": "kitty", "remainingLives": 4 },
    { "type": "dog", "name": "spot", "trained": false }
  ]
}
```

Now consider following unboxing models

```swift
class Animal: Unboxable {
    let name: String
    required init(unboxer: Unboxer) {
        name = unboxer.unbox("name")
    }
}

class Cat: Animal {
    let remainingLives: Int
    required init(unboxer: Unboxer) {
        remainingLives = unboxer.unbox("remainingLives")
        super.init(unboxer: unboxer)
    }
}

class Dog: Animal {
    let isTrained: Bool
    required init(unboxer: Unboxer) {
        isTrained = unboxer.unbox("trained")
        super.init(unboxer: unboxer)
    }
}

enum Type: String, UnboxableEnum {
    case Dog = "dog"
    case Cat = "cat"
    
    static func unboxFallbackValue() -> Type {
        return .Dog
    }
}
```

I don't know if you intended it to be but Unbox supports inheritance with `let` properties which is a really cool thing.
Sadly, though Swift doesn't support class clustering but one can make a Factory-like implementation doing

```swift
let animal: Animal = try Unboxer.performCustomUnboxingWithDictionary(dict) { (unboxer) -> Animal? in
    let type: Type = unboxer.unbox("type")
    switch type {
    case .Dog: return try Unbox(unboxer.dictionary) as Dog
    case .Cat: return try Unbox(unboxer.dictionary) as Cat
    }
}
```

This is a really minor change but it takes away a `do catch` block inside custom unboxing and re-throws whatever error occurs inside