### PR TITLE
Document new UnboxError case + rename to InvalidValueErrors

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -85,6 +85,7 @@ public func Unbox<T: UnboxableWithContext>(data: NSData, context: T.ContextType,
 
 // MARK: - Error type
 
+/// Enum describing unboxing errors that were caused by invalid or missing values
 public enum UnboxValueError: ErrorType, CustomStringConvertible {
     public var description: String {
         switch self {
@@ -95,20 +96,20 @@ public enum UnboxValueError: ErrorType, CustomStringConvertible {
         }
     }
     
-    /// Thrown when a required key was missing in an unboxed dictionary. Contains the missing key.
+    /// Thrown when a required key/value was missing in an unboxed dictionary. Contains the missing key.
     case MissingValueForKey(String)
     /// Thrown when a required key contained an invalid value in an unboxed dictionary. Contains the invalid
     /// key and a description of the invalid data.
     case InvalidValue(String, String)
 }
 
-/// Enum describing errors that can occur during unboxing. Use the throwing functions to receive any errors.
+/// Enum describing errors that can occur during unboxing
 public enum UnboxError: ErrorType, CustomStringConvertible {
     public var description: String {
         let baseDescription = "[Unbox error] "
         
         switch self {
-        case .InvalidInput(let errors):
+        case .InvalidValueErrors(let errors):
             return baseDescription + errors.map{"\($0)"}.joinWithSeparator(", ")
         case .InvalidData:
             return baseDescription + "Invalid NSData"
@@ -117,7 +118,8 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
         }
     }
     
-    case InvalidInput([UnboxValueError])
+    /// Thrown when one or many invalid value errors were encountered. See UnboxValueError for more info.
+    case InvalidValueErrors([UnboxValueError])
     /// Thrown when a piece of data (NSData) could not be unboxed because it was considered invalid
     case InvalidData
     /// Thrown when a custom unboxing closure returned nil
@@ -736,7 +738,7 @@ private extension Unboxer {
             }
         }
         
-        throw UnboxError.InvalidInput(inputErrors)
+        throw UnboxError.InvalidValueErrors(inputErrors)
     }
 }
 

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -109,7 +109,7 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
         let baseDescription = "[Unbox error] "
         
         switch self {
-        case .InvalidValueErrors(let errors):
+        case .InvalidValues(let errors):
             return baseDescription + errors.map{"\($0)"}.joinWithSeparator(", ")
         case .InvalidData:
             return baseDescription + "Invalid NSData"
@@ -118,8 +118,8 @@ public enum UnboxError: ErrorType, CustomStringConvertible {
         }
     }
     
-    /// Thrown when one or many invalid value errors were encountered. See UnboxValueError for more info.
-    case InvalidValueErrors([UnboxValueError])
+    /// Thrown when one or many invalid values were encountered. Contains errors for each value. See UnboxValueError for more info.
+    case InvalidValues([UnboxValueError])
     /// Thrown when a piece of data (NSData) could not be unboxed because it was considered invalid
     case InvalidData
     /// Thrown when a custom unboxing closure returned nil
@@ -738,7 +738,7 @@ private extension Unboxer {
             }
         }
         
-        throw UnboxError.InvalidValueErrors(inputErrors)
+        throw UnboxError.InvalidValues(inputErrors)
     }
 }
 

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -488,7 +488,7 @@ class UnboxTests: XCTestCase {
         do {
             try Unbox(invalidDictionary) as UnboxTestMock
             XCTFail("Unbox should have thrown for a missing value")
-        } catch UnboxError.InvalidValueErrors(let errors) where !errors.isEmpty {
+        } catch UnboxError.InvalidValues(let errors) where !errors.isEmpty {
             guard case .MissingValueForKey(_) = errors.first! else {
                 XCTFail("Unbox did not return the correct error type")
                 return
@@ -510,7 +510,7 @@ class UnboxTests: XCTestCase {
         do {
             try Unbox(invalidDictionary) as UnboxTestMock
             XCTFail("Unbox should have thrown for an invalid value")
-        } catch UnboxError.InvalidValueErrors(let errors) where !errors.isEmpty {
+        } catch UnboxError.InvalidValues(let errors) where !errors.isEmpty {
             guard case .InvalidValue(_, _) = errors.first! else {
                 XCTFail("Unbox did not return the correct error type")
                 return

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -488,7 +488,7 @@ class UnboxTests: XCTestCase {
         do {
             try Unbox(invalidDictionary) as UnboxTestMock
             XCTFail("Unbox should have thrown for a missing value")
-        } catch UnboxError.InvalidInput(let errors) where !errors.isEmpty {
+        } catch UnboxError.InvalidValueErrors(let errors) where !errors.isEmpty {
             guard case .MissingValueForKey(_) = errors.first! else {
                 XCTFail("Unbox did not return the correct error type")
                 return
@@ -510,7 +510,7 @@ class UnboxTests: XCTestCase {
         do {
             try Unbox(invalidDictionary) as UnboxTestMock
             XCTFail("Unbox should have thrown for an invalid value")
-        } catch UnboxError.InvalidInput(let errors) where !errors.isEmpty {
+        } catch UnboxError.InvalidValueErrors(let errors) where !errors.isEmpty {
             guard case .InvalidValue(_, _) = errors.first! else {
                 XCTFail("Unbox did not return the correct error type")
                 return


### PR DESCRIPTION
InvalidInput can be a big ambigious since it may refer to the input as in NSData or a dictionary, a closure, etc. This way it’s clear that we’re referring to underlying errors caused by invalid values.