### PR TITLE
Added flattened custom Array unboxing function

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -408,7 +408,7 @@ public class Unboxer {
     }
     
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, discarding elements producing errors
-    public static func performFlattenedCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) throws -> [T] {
+    public static func performFlattenedCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) -> [T] {
         return array.flatMap { (dictionary) -> T? in
             return try? self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
         }

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -407,6 +407,13 @@ public class Unboxer {
         return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure)
     }
     
+    /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, discarding elements producing errors
+    public static func performFlattenedCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) throws -> [T] {
+        return array.flatMap { (dictionary) -> T? in
+            return try? self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
+        }
+    }
+    
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, or throw an UnboxError
     public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) throws -> [T] {
         var unboxedArray = [T]()

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -407,23 +407,18 @@ public class Unboxer {
         return try Unboxer(dictionary: dictionary, context: context).performCustomUnboxingWithClosure(closure)
     }
     
-    /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, discarding elements producing errors
-    public static func performFlattenedCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) -> [T] {
-        return array.flatMap { (dictionary) -> T? in
-            return try? self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
-        }
-    }
-    
     /// Perform custom unboxing on an array of dictionaries, executing a closure with a new Unboxer for each one, or throw an UnboxError
-    public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, closure: Unboxer throws -> T?) throws -> [T] {
-        var unboxedArray = [T]()
+    public static func performCustomUnboxingWithArray<T>(array: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false, closure: Unboxer throws -> T?) throws -> [T] {
         
-        for dictionary in array {
-            let unboxed = try self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
-            unboxedArray.append(unboxed)
+        if allowInvalidElements {
+            return array.flatMap { (dictionary) -> T? in
+                return try? self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
+            }
+        } else {
+            return try array.map { (dictionary) -> T in
+                return try self.performCustomUnboxingWithDictionary(dictionary, context: context, closure: closure)
+            }
         }
-        
-        return unboxedArray
     }
     
     /// Perform custom unboxing using an Unboxer (created from NSData) passed to a closure, or throw an UnboxError

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -907,6 +907,50 @@ class UnboxTests: XCTestCase {
             XCTFail("Unexpected error thrown: \(error)")
         }
     }
+    
+    func testFlattenedCustomUnboxingFromArrayWithMultipleClasses() {
+        struct ModelA {
+            let int: Int
+        }
+        
+        struct ModelB {
+            let string: String
+        }
+        
+        let array: [UnboxableDictionary] = [
+            [
+                "type" : "A",
+                "int" : 22
+            ],
+            [
+                "type" : "B",
+                "WrongKey" : "hello"
+            ]
+        ]
+        
+        do {
+            let unboxed: [Any] = try Unboxer.performFlattenedCustomUnboxingWithArray(array, closure: {
+                let unboxer = $0
+                let type = unboxer.unbox("type") as String
+                
+                switch type {
+                case "A":
+                    return ModelA(int: unboxer.unbox("int"))
+                case "B":
+                    return ModelB(string: unboxer.unbox("string"))
+                default:
+                    XCTFail()
+                }
+                
+                return nil
+            })
+            
+            XCTAssertEqual((unboxed.first as! ModelA).int, 22)
+            XCTAssertTrue(unboxed.count == 1)
+        } catch {
+            XCTFail("Unexpected error thrown: \(error)")
+        }
+    }
 }
 
 private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool) -> UnboxableDictionary {

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -928,28 +928,24 @@ class UnboxTests: XCTestCase {
             ]
         ]
         
-        do {
-            let unboxed: [Any] = try Unboxer.performFlattenedCustomUnboxingWithArray(array, closure: {
-                let unboxer = $0
-                let type = unboxer.unbox("type") as String
-                
-                switch type {
-                case "A":
-                    return ModelA(int: unboxer.unbox("int"))
-                case "B":
-                    return ModelB(string: unboxer.unbox("string"))
-                default:
-                    XCTFail()
-                }
-                
-                return nil
-            })
+        let unboxed: [Any] = Unboxer.performFlattenedCustomUnboxingWithArray(array, closure: {
+            let unboxer = $0
+            let type = unboxer.unbox("type") as String
             
-            XCTAssertEqual((unboxed.first as! ModelA).int, 22)
-            XCTAssertTrue(unboxed.count == 1)
-        } catch {
-            XCTFail("Unexpected error thrown: \(error)")
-        }
+            switch type {
+            case "A":
+                return ModelA(int: unboxer.unbox("int"))
+            case "B":
+                return ModelB(string: unboxer.unbox("string"))
+            default:
+                XCTFail()
+            }
+            
+            return nil
+        })
+        
+        XCTAssertEqual((unboxed.first as! ModelA).int, 22)
+        XCTAssertTrue(unboxed.count == 1)
     }
 }
 


### PR DESCRIPTION
Hi,

i ran into the problem of unboxing an array of different types and used the `performCustomUnboxingWithArray` function.
But i didn't want to discard everything when there is an error in one element.
So i added `performFlattenedCustomUnboxingWithArray` which does basically the same but returns all elements which didn't fail.
The downside is, that it now never throws an error even if all elements fail to unbox

