### PR TITLE
Feature: Unbox an Array with a formatter and optionally allowing invalid values

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -716,18 +716,17 @@ public class Unboxer {
             if allowInvalidElements {
                 return array.flatMap({ formatter.formatUnboxedValue($0) })
             } else {
-                var invalidElement = false
+                var formattedArray = [T]()
                 
-                let mapping = array.flatMap({ (value) -> T? in
-                    if let formattedValue = formatter.formatUnboxedValue(value) {
-                        return formattedValue
+                for value in array {
+                    guard let formattedValue = formatter.formatUnboxedValue(value) else {
+                        return nil
                     }
                     
-                    invalidElement = true
-                    return nil
-                })
+                    formattedArray.append(formattedValue)
+                }
                 
-                return invalidElement ? nil : mapping
+                return formattedArray
             }
         })
     }

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -692,6 +692,20 @@ public class Unboxer {
         })
     }
     
+    /// Unbox a required Array containing values that can be formatted using a formatter
+    public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, isKeyPath: Bool = true, formatter: F) -> [T] {
+        return UnboxValueResolver<[F.UnboxRawValueType]>(self).resolveRequiredValueForKey(key, isKeyPath: isKeyPath, fallbackValue: [], transform: { (array) -> [T]? in
+            return array.flatMap({ formatter.formatUnboxedValue($0) })
+        })
+    }
+    
+    /// Unbox an optional Array containing values that can be formatted using a formatter
+    public func unbox<T: UnboxableWithFormatter, F: UnboxFormatter where F.UnboxFormattedType == T>(key: String, isKeyPath: Bool = true, formatter: F) -> [T]? {
+        return UnboxValueResolver<[F.UnboxRawValueType]>(self).resolveOptionalValueForKey(key, isKeyPath: isKeyPath, transform: { (array) -> [T]? in
+            return array.flatMap({ formatter.formatUnboxedValue($0) })
+        })
+    }
+    
     /// Make this Unboxer fail for a certain key. This will cause the `Unbox()` function that triggered this Unboxer to return `nil`.
     public func failForKey(key: String) {
         self.failForInvalidValue(nil, forKey: key)

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -262,6 +262,8 @@ class UnboxTests: XCTestCase {
             
             let unboxed: AllowInvalidElementsModel = try Unbox(invalidValueDateArrayDictionary)
             
+            XCTAssertEqual(unboxed.dateArray.count, 1)
+            
             if let firstDate = unboxed.dateArray.first {
                 let calendar = NSCalendar.currentCalendar()
                 XCTAssertEqual(calendar.component(.Year, fromDate: firstDate), 2015)
@@ -347,6 +349,7 @@ class UnboxTests: XCTestCase {
             
             let unboxed: AllowInvalidElementsModel = try Unbox(invalidDictionary)
             XCTAssertNil(unboxed.date)
+            XCTAssertEqual(unboxed.dateArray?.count, 1)
             
             let calendar = NSCalendar.currentCalendar()
             if let firstDate = unboxed.dateArray?.first {


### PR DESCRIPTION
We needed to unbox an array of `String`s with a specific date format into an array of `NSDate`s, so we added this functionality to unbox.

Would appreciate it if you could make a release with this in asap :smiley: