### PR TITLE
Update README to declare Unboxable in extension of struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ That can be initialized with the following JSON:
 To decode this JSON into a `User` instance, all you have to do is make `User` conform to `Unboxable` and unbox its properties:
 
 ```swift
-struct User: Unboxable {
+struct User {
     let name: String
     let age: Int
+}
 
+extension User: Unboxable {
     init(unboxer: Unboxer) {
         self.name = unboxer.unbox("name")
         self.age = unboxer.unbox("age")
@@ -57,7 +59,7 @@ let user: User = try Unbox(data)
 The first was a pretty simple example, but Unbox can decode even the most complicated JSON structures for you, with both required and optional values, all without any extra code on your part:
 
 ```swift
-struct SpaceShip: Unboxable {
+struct SpaceShip {
     let type: SpaceShipType
     let weight: Double
     let engine: Engine
@@ -65,7 +67,9 @@ struct SpaceShip: Unboxable {
     let launchLiveStreamURL: NSURL?
     let lastPilot: Astronaut?
     let lastLaunchDate: NSDate?
+}
 
+extension SpaceShip: Unboxable {
     init(unboxer: Unboxer) {
         self.type = unboxer.unbox("type")
         self.weight = unboxer.unbox("weight")
@@ -80,34 +84,38 @@ struct SpaceShip: Unboxable {
     }
 }
 
-enum SpaceShipType: Int, UnboxableEnum {
+enum SpaceShipType: Int {
     case Apollo
     case Sputnik
+}
 
+extension SpaceShipType: UnboxableEnum {
     static func unboxFallbackValue() -> SpaceShipType {
         return .Apollo
     }
 }
 
-struct Engine: Unboxable {
+struct Engine {
     let manufacturer: String
     let fuelConsumption: Float
+}
 
+extension Engine: Unboxable {
     init(unboxer: Unboxer) {
         self.manufacturer = unboxer.unbox("manufacturer")
         self.fuelConsumption = unboxer.unbox("fuelConsumption")
     }
 }
 
-struct Astronaut: Unboxable {
+struct Astronaut {
     let name: String
+}
 
+extension Astronaut: Unboxable {
     init(unboxer: Unboxer) {
         self.name = unboxer.unbox("name")
     }
 }
-
-
 ```
 
 ### Error handling


### PR DESCRIPTION
This PR changes the README to declare `Unboxable` in extensions to structs rather than on the struct itself.

If you define your model object with the following:

```swift
struct Player: Unboxable {
    let name: String

    init(unboxer: Unboxer) {
        self.name = unboxer.unbox("name")
    }
}
```
then you cannot do `let player = Player(name: "Jóhann")` without additional boilerplate. This is because Swift doesn't give you access to the default struct initializer if you define a custom initializer (see *Initializer Delegate for Value Types* in [the documentation](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Initialization.html)).

Apple suggests that you define your custom initializer in an extension to bypass this issue. By making the model conform to Unboxable in an extension, we will retain the default initializer. 

```swift
struct Player {
    let name: String
}

extension Player: Unboxable {
    init(unboxer: Unboxer) {
        self.name = unboxer.unbox("name")
    }
}
```
Now we can both use `let player = Player(name: "Jóhann")` and Unbox without any additional boilerplate.

It also decouples Unbox from the model and makes it possible to declare the models and the deserialization method using Unbox in two separate files.

This initializer behavior was not obvious to me when starting to use Unboxable so I suggest that the documentation should show this approach.