### PR TITLE
UnboxError and UnboxValueError cast easily to NSError

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -206,6 +206,14 @@ public protocol UnboxFormatter {
     func formatUnboxedValue(unboxedValue: UnboxRawValueType) -> UnboxFormattedType?
 }
 
+/// Protocol which allows for Unbox ErrorTypes to easily convert to NSError
+public protocol CustomErrorConvertible {
+    var domain: String { get }
+    var code: Int { get }
+    var userInfo: [String: String]? { get }
+    var error: NSError { get }
+}
+
 // MARK: - Extensions
 
 /// Extension making Bool an Unboxable raw type
@@ -310,6 +318,39 @@ extension Float: UnboxableRawType {
     
     public static func transformUnboxedString(unboxedString: String) -> Float? {
         return Float(unboxedString)
+    }
+}
+
+/// Extension implementing default behavior for CustomErrorConvertible
+public extension CustomErrorConvertible where Self: CustomStringConvertible {
+    public var userInfo: [String: String]? {
+        return [NSLocalizedDescriptionKey: self.description]
+    }
+    
+    public var error: NSError {
+        return NSError(domain: self.domain, code: self.code, userInfo: self.userInfo)
+    }
+}
+
+/// Extension making UnboxError conform to CustomeErrorConvertible
+extension UnboxError: CustomErrorConvertible {
+    public var domain: String {
+        return "UnboxError"
+    }
+    
+    public var code: Int {
+        return 1
+    }
+}
+
+/// Extension making UnboxValueError conform to CustomeErrorConvertible
+extension UnboxValueError: CustomErrorConvertible {
+    public var domain: String {
+        return "UnboxValueError"
+    }
+    
+    public var code: Int {
+        return 0
     }
 }
 

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -321,12 +321,15 @@ extension Float: UnboxableRawType {
     }
 }
 
-/// Extension implementing default behavior for CustomErrorConvertible
-public extension CustomErrorConvertible where Self: CustomStringConvertible {
+/// Extension implementing default user for CustomErrorConvertible which are also CustomStringConvertible
+extension CustomErrorConvertible where Self: CustomStringConvertible {
     public var userInfo: [String: String]? {
         return [NSLocalizedDescriptionKey: self.description]
     }
-    
+}
+
+/// Extension implementing default error for CustomErrorConvertible
+extension CustomErrorConvertible {
     public var error: NSError {
         return NSError(domain: self.domain, code: self.code, userInfo: self.userInfo)
     }

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -321,17 +321,24 @@ extension Float: UnboxableRawType {
     }
 }
 
-/// Extension implementing default user for CustomErrorConvertible which are also CustomStringConvertible
+/// Extension implementing default error for CustomErrorConvertible
+extension CustomErrorConvertible {
+    public var error: NSError {
+        return NSError(domain: self.domain, code: self.code, userInfo: self.userInfo)
+    }
+}
+
+/// Extension implementing default user for CustomErrorConvertible which is also CustomStringConvertible
 extension CustomErrorConvertible where Self: CustomStringConvertible {
     public var userInfo: [String: String]? {
         return [NSLocalizedDescriptionKey: self.description]
     }
 }
 
-/// Extension implementing default error for CustomErrorConvertible
-extension CustomErrorConvertible {
-    public var error: NSError {
-        return NSError(domain: self.domain, code: self.code, userInfo: self.userInfo)
+/// Extension implementing default code for CustomErrorConvertible which is also an ErrorType
+extension CustomErrorConvertible where Self: ErrorType {
+    public var code: Int {
+        return self._code
     }
 }
 
@@ -340,20 +347,12 @@ extension UnboxError: CustomErrorConvertible {
     public var domain: String {
         return "UnboxError"
     }
-    
-    public var code: Int {
-        return 1
-    }
 }
 
 /// Extension making UnboxValueError conform to CustomeErrorConvertible
 extension UnboxValueError: CustomErrorConvertible {
     public var domain: String {
         return "UnboxValueError"
-    }
-    
-    public var code: Int {
-        return 0
     }
 }
 


### PR DESCRIPTION
I'm working on a pull request for a community extension which requires the use of `NSError`s. I've created a protocol and few extensions which help quickly map Unbox's errors to `NSError` so we don't lose any valuable information about errors during unboxing when printing out `NSError`s.

I considered placing this in the community extension itself, but I realized that future community extensions might need to make use of this feature and it would be unwise for each extension to create their own implementation which could cause fractures. 