### PR TITLE
Fix unboxed Int to String transformation

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -341,7 +341,7 @@ extension String: UnboxableRawType {
     }
     
     public static func transformUnboxedInt(unboxedInt: Int) -> String? {
-        return nil
+        return String(unboxedInt)
     }
     
     public static func transformUnboxedString(unboxedString: String) -> String? {


### PR DESCRIPTION
If property is declared as String, and API returns an Int, unboxing would fail.
Not sure why this line was set to always return nil for unboxed Int transformation to String (mistake maybe?), but this commit fixes this issue.