### PR TITLE
Add ISO8601DateFormatter to date formatters

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -358,8 +358,15 @@ extension Date: UnboxableWithFormatter {
     }
 }
 
-/// Extension making DateFormatter usable as a UnboxFormatter
+/// Extension making DateFormatter usable as an UnboxFormatter
 extension DateFormatter: UnboxFormatter {
+    public func format(unboxedValue: String) -> Date? {
+        return self.date(from: unboxedValue)
+    }
+}
+
+/// Extension making ISO8601DateFormatter usable as an UnboxFormatter
+extension ISO8601DateFormatter: UnboxFormatter {
     public func format(unboxedValue: String) -> Date? {
         return self.date(from: unboxedValue)
     }


### PR DESCRIPTION
Proposal: Use it by default when no formatter is specified ?

Fallback needed ?

```swift
class ISO8601DateFormatter: DateFormatter {

    override init() {
        super.init()

        self.locale     = Locale(identifier: "en_US_POSIX")
        self.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
        self.timeZone   = TimeZone(secondsFromGMT: 0)
    }

    required init?(coder aDecoder: NSCoder) {
        super.init(coder:aDecoder)
    }
}
```