### PR TITLE
Add support for unboxing objects conforming to UnboxableWithContext from a provided key.

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -47,6 +47,13 @@ public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, at key: String,
     return container.model
 }
 
+/// Unbox a JSON dictionary into a model `T` beginning at a provided key, optionally using a contextual object. Throws `UnboxError`.
+public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, at key: String, isKeyPath: Bool = true, context: T.ContextType) throws -> T {
+    let containerContext = UnboxContainerContext(key: key, isKeyPath: isKeyPath, context: context)
+    let container: UnboxWithContextContainer<T> = try Unbox(dictionary, context: containerContext)
+    return container.model
+}
+
 /// Unbox an array of JSON dictionaries into an array of `T`, optionally using a contextual object and/or invalid elements. Throws `UnboxError`.
 public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: Any? = nil, allowInvalidElements: Bool = false) throws -> [T] {
     return try dictionaries.mapAllowingInvalidElements(allowInvalidElements, transform: {
@@ -58,6 +65,13 @@ public func Unbox<T: Unboxable>(dictionaries: [UnboxableDictionary], context: An
 public func Unbox<T: Unboxable>(dictionary: UnboxableDictionary, at key: String, isKeyPath: Bool = true, context: Any? = nil) throws -> [T] {
     let containerContext = UnboxContainerContext(key: key, isKeyPath: isKeyPath, context: context)
     let container: UnboxArrayContainer<T> = try Unbox(dictionary, context: containerContext)
+    return container.models
+}
+
+/// Unbox an array JSON dictionary into an array of model `T` beginning at a provided key, optionally using a contextual object. Throws `UnboxError`.
+public func Unbox<T: UnboxableWithContext>(dictionary: UnboxableDictionary, at key: String, isKeyPath: Bool = true, context: T.ContextType) throws -> [T] {
+    let containerContext = UnboxContainerContext(key: key, isKeyPath: isKeyPath, context: context)
+    let container: UnboxArrayWithContextContainer<T> = try Unbox(dictionary, context: containerContext)
     return container.models
 }
 
@@ -888,16 +902,16 @@ extension UnboxValueResolver where T: CollectionType, T: DictionaryLiteralConver
 
 // MARK: - UnboxContainerContext
 
-private struct UnboxContainerContext {
+private struct UnboxContainerContext<T> {
     let key: String
     let isKeyPath: Bool
-    let context: Any?
+    let context: T
 }
 
 private struct UnboxContainer<T: Unboxable>: UnboxableWithContext {
     let model: T
     
-    init(unboxer: Unboxer, context: UnboxContainerContext) {
+    init(unboxer: Unboxer, context: UnboxContainerContext<Any>) {
         self.model = unboxer.unbox(context.key, isKeyPath: context.isKeyPath, context: context.context)
     }
 }
@@ -905,8 +919,24 @@ private struct UnboxContainer<T: Unboxable>: UnboxableWithContext {
 private struct UnboxArrayContainer<T: Unboxable>: UnboxableWithContext {
     let models: [T]
     
-    init(unboxer: Unboxer, context: UnboxContainerContext) {
+    init(unboxer: Unboxer, context: UnboxContainerContext<Any>) {
         self.models = unboxer.unbox(context.key, isKeyPath: context.isKeyPath)
+    }
+}
+
+private struct UnboxWithContextContainer<T: UnboxableWithContext>: UnboxableWithContext {
+    let model: T
+
+    init(unboxer: Unboxer, context: UnboxContainerContext<T.ContextType>) {
+        self.model = unboxer.unbox(context.key, isKeyPath: context.isKeyPath, context: context.context)
+    }
+}
+
+private struct UnboxArrayWithContextContainer<T: UnboxableWithContext>: UnboxableWithContext {
+    let models: [T]
+
+    init(unboxer: Unboxer, context: UnboxContainerContext<T.ContextType>) {
+        self.models = unboxer.unbox(context.key, isKeyPath: context.isKeyPath, context: context.context)
     }
 }
 

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -1357,6 +1357,73 @@ class UnboxTests: XCTestCase {
             // Test Passed
         }
     }
+
+    func testUnboxingObjectWithContextAtCustomKeyPath() {
+        let dictionary = [
+            "at_key": [
+                "nested" : [:],
+                "nestedArray": [[:]]
+            ]
+        ]
+
+        do {
+            let model: UnboxTestContextMock = try Unbox(dictionary, at: "at_key", context: "this context")
+            XCTAssertEqual(model.context, "this context")
+
+            if let nestedModel = model.nested {
+                XCTAssertEqual(nestedModel.context, "nestedContext")
+            } else {
+                XCTFail("Failed to unbox nested model")
+            }
+
+            if let nestedArrayModel = model.nestedArray?.first {
+                XCTAssertEqual(nestedArrayModel.context, "nestedArrayContext")
+            } else {
+                XCTFail("Failed to unbox nested model array")
+            }
+
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testUnboxingArrayOfObjectWithContextAtCustomKeyPath() {
+        let dictionary = [
+            "at_key": [
+                [
+                    "nested" : [:],
+                    "nestedArray": [[:]],
+                ],
+                [
+                    "nested" : [:],
+                    "nestedArray": [[:]],
+                ]
+            ]
+        ]
+
+        do {
+            let models: [UnboxTestContextMock] = try Unbox(dictionary, at: "at_key", context: "this context")
+            XCTAssertEqual(models.count, 2)
+            let model = models.first!
+            XCTAssertEqual(model.context, "this context")
+
+            if let nestedModel = model.nested {
+                XCTAssertEqual(nestedModel.context, "nestedContext")
+            } else {
+                XCTFail("Failed to unbox nested model")
+            }
+
+            if let nestedArrayModel = model.nestedArray?.first {
+                XCTAssertEqual(nestedArrayModel.context, "nestedArrayContext")
+            } else {
+                XCTFail("Failed to unbox nested model array")
+            }
+
+        } catch {
+            XCTFail()
+        }
+    }
+
     
     func testUnboxingArrayOfStringsTransformedToInt() {
         let dictionary: UnboxableDictionary = ["intArray": ["123", "456", "789"]]


### PR DESCRIPTION
Add support for unboxing objects conforming to UnboxableWithContext from a provided key. Fixed #128 

This PR would need to go into 1.9 if you want to do a 1.9.1 release. I totally understand if you don't want to do any more pre 2.0 releases, but as we need this, I'm happy to contribute it back if anyone else is interested. 

As there is no branch for 1.9 I couldn't find a way to get Github to direct this to the right commit. If you decide you want to merge this, can you create a branch, ping me and I'll update the PR.
