### PR TITLE
Unbox 2.2.0

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -114,20 +114,6 @@ public struct UnboxError: Error, CustomStringConvertible {
     }
 }
 
-private extension UnboxError {
-    static var invalidData: UnboxError {
-        return UnboxError(description: "Invalid data.")
-    }
-    
-    static var customUnboxingFailed: UnboxError {
-        return UnboxError(description: "Custom unboxing failed.")
-    }
-    
-    init(path: UnboxPath, description: String) {
-        self.init(description: "An error occured while unboxing path \"\(path)\": \(description)")
-    }
-}
-
 // MARK: - Protocols
 
 /// Protocol used to declare a model as being Unboxable, for use with the unbox() function
@@ -839,6 +825,20 @@ private extension UnboxFormatter {
             let transformer = UnboxFormatterCollectionElementTransformer(formatter: self)
             return try C.unbox(value: $0, allowInvalidElements: allowInvalidElements, transformer: transformer)
         }
+    }
+}
+
+private extension UnboxError {
+    static var invalidData: UnboxError {
+        return UnboxError(description: "Invalid data.")
+    }
+    
+    static var customUnboxingFailed: UnboxError {
+        return UnboxError(description: "Custom unboxing failed.")
+    }
+    
+    init(path: UnboxPath, description: String) {
+        self.init(description: "An error occured while unboxing path \"\(path)\": \(description)")
     }
 }
 

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -483,13 +483,6 @@ extension Decimal: UnboxableByTransform {
     }
 }
 
-/// Extension making String values usable as an Unboxable keys
-extension String: UnboxableKey {
-    public static func transform(unboxedKey: String) -> String? {
-        return unboxedKey
-    }
-}
-
 /// Extension making DateFormatter usable as a UnboxFormatter
 extension DateFormatter: UnboxFormatter {
     public func format(unboxedValue: String) -> Date? {

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -1519,7 +1519,7 @@ class UnboxTests: XCTestCase {
             _ = try unbox(dictionary: dictionary) as Model
             XCTFail("Should have thrown")
         } catch {
-            XCTAssertEqual("\(error)", "[UnboxError] An error occured while unboxing path \"array\": Invalid array element type: ObjectIdentifier. Must be UnboxCompatible or Unboxable.")
+            XCTAssertEqual("\(error)", "[UnboxError] An error occured while unboxing path \"array\": Invalid collection element type: ObjectIdentifier. Must be UnboxCompatible or Unboxable.")
         }
     }
     
@@ -1582,7 +1582,7 @@ class UnboxTests: XCTestCase {
             _ = try unbox(dictionary: dictionary) as Model
             XCTFail("Should have thrown")
         } catch {
-            XCTAssertEqual("\(error)", "[UnboxError] An error occured while unboxing path \"dictionary\": Invalid dictionary value type: ObjectIdentifier. Must be UnboxCompatible or Unboxable.")
+            XCTAssertEqual("\(error)", "[UnboxError] An error occured while unboxing path \"dictionary\": Invalid collection element type: ObjectIdentifier. Must be UnboxCompatible or Unboxable.")
         }
     }
     

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -1502,6 +1502,48 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testThrowingForArrayWithInvalidElementType() {
+        struct Model: Unboxable {
+            let array: [ObjectIdentifier]
+            
+            init(unboxer: Unboxer) throws {
+                self.array = try unboxer.unbox(key: "array")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "array" : ["value"]
+        ]
+        
+        do {
+            _ = try unbox(dictionary: dictionary) as Model
+            XCTFail("Should have thrown")
+        } catch {
+            XCTAssertEqual("\(error)", "[UnboxError] An error occured while unboxing path \"array\": Invalid array element type: ObjectIdentifier. Must be UnboxCompatible or Unboxable.")
+        }
+    }
+    
+    func testThrowingForArrayWithInvalidElement() {
+        struct Model: Unboxable {
+            let array: [String]
+            
+            init(unboxer: Unboxer) throws {
+                self.array = try unboxer.unbox(key: "array")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "array" : [[:]]
+        ]
+        
+        do {
+            _ = try unbox(dictionary: dictionary) as Model
+            XCTFail("Should have thrown")
+        } catch {
+            XCTAssertEqual("\(error)", "[UnboxError] An error occured while unboxing path \"array\": Invalid array element ([:]) at index 0.")
+        }
+    }
+    
     func testThrowingForDictionaryWithInvalidKeyType() {
         struct Model: Unboxable {
             let dictionary: [ObjectIdentifier : String]


### PR DESCRIPTION
This is the release branch for version `2.2.0` of Unbox. This release has 2 goals:

1. Performance. Unboxing collections has been made ~25% faster, thanks to decreased iteration complexity - and key path-based unboxing has been made ~50% faster due to not using associated enum values.

2. Simplified error API. Unbox has always provided a thorough error reporting API, but this has now been a lot simpler to use - with a single `UnboxError` struct that comes with readable, easy to debug error descriptions.