### PR TITLE
Exclude Tests in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "Unbox"
+    name: "Unbox",
+    exclude: ["Tests"]
 )


### PR DESCRIPTION
Problem - With Xcode 8.1 and Swift 3.0.1 toolchain (afair 3.0.0 also) it is impossible to build the project as a dependency because of `Tests` folder.
Getting error message:
```
Cloning https://github.com/JohnSundell/Unbox.git
HEAD is now at a0f1fd8 Merge pull request #134 from JohnSundell/2.2.0
Resolved version: 2.2.0
error: the package has an unsupported layout, unexpected source file(s) found: /Users/laskowski/test-project/Packages/Unbox-2.2.0/Tests/UnboxTests.swift
fix: move the file(s) inside a module
```

Fix - added `Tests` folder to `exclude`

Please create a new tag if possible, so this change will be visible via SPM.