### PR TITLE
Make initializer for `UnboxError` public

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -109,7 +109,7 @@ public func unbox<T: UnboxableWithContext>(data: Data, context: T.UnboxContext, 
 public struct UnboxError: Error, CustomStringConvertible {
     public let description: String
     
-    fileprivate init(description: String) {
+    public init(description: String) {
         self.description = "[UnboxError] " + description
     }
 }


### PR DESCRIPTION
This PR makes the initializer for `UnboxError` public so that consumers can create their own custom `UnboxError` if desired.

This is a quick fix solution to #136, which I imagine will actually suffice for many/most consumers.