### PR TITLE
Feature/fix url bug

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -499,13 +499,10 @@ extension URL: UnboxableByTransform {
     public typealias UnboxRawValue = String
     
     public static func transform(unboxedValue: String) -> URL? {
-        let regEx = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+"
-        let predicate = NSPredicate(format:"SELF MATCHES %@", argumentArray:[regEx])
-        if !predicate.evaluate(with: unboxedValue) { return nil }
-        
         guard let url = URL(string: unboxedValue) else {
             return URL(string: unboxedValue.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlPathAllowed)!)
         }
+        
         return url
     }
 }

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -499,7 +499,14 @@ extension URL: UnboxableByTransform {
     public typealias UnboxRawValue = String
     
     public static func transform(unboxedValue: String) -> URL? {
-        return URL(string: unboxedValue)
+        let regEx = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+"
+        let predicate = NSPredicate(format:"SELF MATCHES %@", argumentArray:[regEx])
+        if !predicate.evaluate(with: unboxedValue) { return nil }
+        
+        guard let url = URL(string: unboxedValue) else {
+            return URL(string: unboxedValue.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlPathAllowed)!)
+        }
+        return url
     }
 }
 

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -258,6 +258,27 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testURLWithAposthrope(){
+        struct Model: Unboxable {
+            let urlWithAposthrope: URL?
+            
+            init(unboxer: Unboxer) throws {
+                self.urlWithAposthrope = unboxer.unbox(key: "urlWithAposthrope")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "urlWithAposthrope" : ["https://www.dummy.url/don`t-fail!!"],
+        ]
+        
+        do {
+            let unboxed: Model = try unbox(dictionary: dictionary)
+            XCTAssertEqual(unboxed.urlWithAposthrope, URL(string: "https://www.dummy.url/don`t-fail"))
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
     func testArrayOfURLs() {
         struct Model: Unboxable {
             let optional: [URL]?

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -37,11 +37,24 @@ class UnboxTests: XCTestCase {
     }
     
     func testWithInvalidRequiredURL() {
-        var invalidDictionary = UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: false)
-        invalidDictionary[UnboxTestMock.requiredURLKey] = "Clearly not a URL!"
+        struct Model: Unboxable {
+            let invalidURL: URL?
+            
+            init(unboxer: Unboxer) throws {
+                self.invalidURL = unboxer.unbox(key: "invalidURL")
+            }
+        }
         
-        let unboxed: UnboxTestMock? = try? unbox(dictionary: invalidDictionary)
-        XCTAssertNil(unboxed, "Unbox did not return nil for a dictionary with an invalid required URL value")
+        let dictionary: UnboxableDictionary = [
+            "invalidURL" : "not an url ??",
+            ]
+        
+        do {
+            let unboxed: Model = try unbox(dictionary: dictionary)
+            XCTAssertEqual(unboxed.invalidURL, URL(string: "not%20an%20url%20%3F%3F"))
+        } catch {
+            XCTFail("\(error)")
+        }
     }
     
     func testAutomaticTransformationOfStringsToRawTypes() {
@@ -268,12 +281,12 @@ class UnboxTests: XCTestCase {
         }
         
         let dictionary: UnboxableDictionary = [
-            "urlWithAposthrope" : ["https://www.dummy.url/don`t-fail!!"],
+            "urlWithAposthrope" : "https://www.dummy.url/don`t-fail",
         ]
         
         do {
             let unboxed: Model = try unbox(dictionary: dictionary)
-            XCTAssertEqual(unboxed.urlWithAposthrope, URL(string: "https://www.dummy.url/don`t-fail"))
+            XCTAssertEqual(unboxed.urlWithAposthrope, URL(string: "https://www.dummy.url/don%60t-fail"))
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
Fix bug on unbox an url with aposthrope like http://www.dummy.url/don`t-fail by replace it with percent encoding