### PR TITLE
Implement arbitrary unknown keys unboxing to dictionary

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -107,6 +107,30 @@ public func unbox<T: UnboxableWithContext>(data: Data, context: T.UnboxContext, 
     return try data.unbox(context: context, allowInvalidElements: allowInvalidElements)
 }
 
+/// Unbox binary data into a dictionary of type `[String: T]`. Throws `UnboxError`.
+public func unbox<T: Unboxable>(data: Data) throws -> [String: T] {
+    let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: [String: Any]]
+    var mappedDictionary = [String: T]()
+    try json?.forEach  { key, value in
+        let data : T = try unbox(dictionary: value)
+        mappedDictionary[key] = data
+    }
+    return mappedDictionary
+}
+
+/// Unbox `UnboxableDictionary` into a dictionary of type `[String: T]` where `T` is `Unboxable`. Throws `UnboxError`.
+public func unbox<T: Unboxable>(dictionary: UnboxableDictionary) throws -> [String: T] {
+    var mappedDictionary = [String: T]()
+    try dictionary.forEach { key, value in
+        guard let innerDictionary = value as? UnboxableDictionary else {
+            throw UnboxError.invalidData
+        }
+        let data : T = try unbox(dictionary: innerDictionary)
+        mappedDictionary[key] = data
+    }
+    return mappedDictionary
+}
+
 // MARK: - Error type
 
 /// Error type that Unbox throws in case an unrecoverable error was encountered

--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -109,13 +109,8 @@ public func unbox<T: UnboxableWithContext>(data: Data, context: T.UnboxContext, 
 
 /// Unbox binary data into a dictionary of type `[String: T]`. Throws `UnboxError`.
 public func unbox<T: Unboxable>(data: Data) throws -> [String: T] {
-    let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: [String: Any]]
-    var mappedDictionary = [String: T]()
-    try json?.forEach  { key, value in
-        let data : T = try unbox(dictionary: value)
-        mappedDictionary[key] = data
-    }
-    return mappedDictionary
+    let dictionary : [String: [String: Any]] = try JSONSerialization.unbox(data: data)
+    return try unbox(dictionary: dictionary)
 }
 
 /// Unbox `UnboxableDictionary` into a dictionary of type `[String: T]` where `T` is `Unboxable`. Throws `UnboxError`.

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -736,6 +736,78 @@ class UnboxTests: XCTestCase {
         }
     }
     
+    func testUnboxingFromArbitraryKeysDictionary() {
+        struct Model: Unboxable {
+            let required: String
+            let optional: String?
+            
+            init(unboxer: Unboxer) throws {
+                required = try unboxer.unbox(key: "required")
+                optional = unboxer.unbox(key: "optional")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "random_unique_data_1" : [
+                "required" : "Hello",
+                "optional" : "World"
+            ],
+            "random_unique_data_2" : [
+                "required" : "Unbox",
+                "optional" : "Test"
+            ]
+        ]
+        
+        do {
+            let unboxed: [String: Model] = try unbox(dictionary: dictionary)
+            XCTAssertEqual(unboxed["random_unique_data_1"]?.required, "Hello")
+            XCTAssertEqual(unboxed["random_unique_data_1"]?.optional, "World")
+            XCTAssertEqual(unboxed["random_unique_data_2"]?.required, "Unbox")
+            XCTAssertEqual(unboxed["random_unique_data_2"]?.optional, "Test")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testUnboxingFromArbitraryKeysData() {
+        struct Model: Unboxable {
+            let required: String
+            let optional: String?
+            
+            init(unboxer: Unboxer) throws {
+                required = try unboxer.unbox(key: "required")
+                optional = unboxer.unbox(key: "optional")
+            }
+        }
+        
+        let dictionary: UnboxableDictionary = [
+            "random_unique_data_1" : [
+                "required" : "Hello",
+                "optional" : "World"
+            ],
+            "random_unique_data_2" : [
+                "required" : "Unbox",
+                "optional" : "Test"
+            ]
+        ]
+        
+        guard let data = try? JSONSerialization.data(withJSONObject: dictionary, options: []) else {
+            XCTFail("Failed to serialize dictionary to data")
+            return
+        }
+        
+        do {
+            let unboxed: [String: Model] = try unbox(data: data)
+            XCTAssertEqual(unboxed["random_unique_data_1"]?.required, "Hello")
+            XCTAssertEqual(unboxed["random_unique_data_1"]?.optional, "World")
+            XCTAssertEqual(unboxed["random_unique_data_2"]?.required, "Unbox")
+            XCTAssertEqual(unboxed["random_unique_data_2"]?.optional, "Test")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+    }
+    
     func testUnboxingValueFromArray() {
         struct Model: Unboxable {
             let required: String


### PR DESCRIPTION
Implemented arbitrary keys dictionary unboxing.
It's not possible to unbox the following structure:

```swift
let data: [String: Model] = try unbox(dictionary: dictionary)
```

and 

```swift
let data: [String: Model] = try unbox(data: data)
```

The tests have been written for both cases