### PR TITLE
Feature/decimal unboxable raw type

### DIFF
--- a/Sources/Unbox.swift
+++ b/Sources/Unbox.swift
@@ -439,6 +439,17 @@ extension Float: UnboxableRawType {
     }
 }
 
+/// Extension making Decimal an Unboxable raw type
+extension Decimal: UnboxableRawType {
+    public static func transform(unboxedNumber: NSNumber) -> Decimal? {
+        return Decimal(string: unboxedNumber.stringValue)
+    }
+    
+    public static func transform(unboxedString unboxedValue: String) -> Decimal? {
+        return Decimal(string: unboxedValue)
+    }
+}
+
 /// Extension making Array an unboxable collection
 extension Array: UnboxableCollection {
     public typealias UnboxValue = Element
@@ -519,15 +530,6 @@ extension URL: UnboxableByTransform {
     
     public static func transform(unboxedValue: String) -> URL? {
         return URL(string: unboxedValue)
-    }
-}
-
-/// Extension making Decimal Unboxable by transform
-extension Decimal: UnboxableByTransform {
-    public typealias UnboxRawValue = String
-
-    public static func transform(unboxedValue: String) -> Decimal? {
-        return self.init(string: unboxedValue)
     }
 }
 

--- a/Tests/UnboxTests.swift
+++ b/Tests/UnboxTests.swift
@@ -1723,7 +1723,7 @@ private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool)
         UnboxTestMock.requiredEnumKey : 1,
         UnboxTestMock.requiredStringKey :  "hello",
         UnboxTestMock.requiredURLKey : "http://www.google.com",
-        UnboxTestMock.requiredDecimalKey: "13.95",
+        UnboxTestMock.requiredDecimalKey: Decimal(13.95) as AnyObject,
         UnboxTestMock.requiredArrayKey : ["unbox", "is", "pretty", "cool", "right?"],
         UnboxTestMock.requiredEnumArrayKey : [0, 1],
     ]
@@ -1855,6 +1855,10 @@ private class UnboxTestBaseMock: Unboxable {
                 verificationOutcome = self.verifyPropertyValue(value: self.requiredFloat, againstDictionaryValue: value)
             case UnboxTestBaseMock.optionalFloatKey:
                 verificationOutcome = self.verifyPropertyValue(value: self.optionalFloat, againstDictionaryValue: value)
+            case UnboxTestBaseMock.requiredDecimalKey:
+                verificationOutcome = self.verifyPropertyValue(value: self.requiredDecimal, againstDictionaryValue: value)
+            case UnboxTestBaseMock.optionalDecimalKey:
+                verificationOutcome = self.verifyPropertyValue(value: self.optionalDecimal, againstDictionaryValue: value)
             case UnboxTestBaseMock.requiredCGFloatKey:
                 verificationOutcome = self.verifyTransformableValue(value: self.requiredCGFloat, againstDictionaryValue: value)
             case UnboxTestBaseMock.optionalCGFloatKey:
@@ -1871,10 +1875,6 @@ private class UnboxTestBaseMock: Unboxable {
                 verificationOutcome = self.verifyTransformableValue(value: self.requiredURL, againstDictionaryValue: value)
             case UnboxTestBaseMock.optionalURLKey:
                 verificationOutcome = self.verifyTransformableValue(value: self.optionalURL, againstDictionaryValue: value)
-            case UnboxTestBaseMock.requiredDecimalKey:
-                verificationOutcome = self.verifyTransformableValue(value: self.requiredDecimal, againstDictionaryValue: value)
-            case UnboxTestBaseMock.optionalDecimalKey:
-                verificationOutcome = self.verifyTransformableValue(value: self.optionalDecimal, againstDictionaryValue: value)
             case UnboxTestBaseMock.requiredArrayKey:
                 verificationOutcome = self.verifyArrayPropertyValue(value: self.requiredArray, againstDictionaryValue: value)
             case UnboxTestBaseMock.optionalArrayKey:


### PR DESCRIPTION
Currently unbox supports transforming to the `Decimal` type for string values, but it does not support transformation from numbers.

The advantage of using this over Double would be to allow us to do more accurate numeric operations on these values.

This PR makes `Decimal` conform to `UnboxableRawType` so it works with numbers and strings. 