### PR TITLE
Fix: When unboxing with keyPath,  try only transform when is the last component

### DIFF
--- a/Sources/Unboxer.swift
+++ b/Sources/Unboxer.swift
@@ -224,14 +224,15 @@ private extension Unboxer {
             case .keyPath(let keyPath):
                 var node: UnboxPathNode = self.dictionary
                 let components = keyPath.components(separatedBy: ".")
-                let lastKey = components.last
+                let keyCounter = components.count
+                var i = 1
 
                 for key in components {
                     guard let nextValue = node.unboxPathValue(forKey: key) else {
                         throw UnboxPathError.missingKey(key)
                     }
 
-                    if key == lastKey {
+                    if i == keyCounter {
                         return try transform(nextValue).orThrow(UnboxPathError.invalidValue(nextValue, key))
                     }
 
@@ -239,6 +240,7 @@ private extension Unboxer {
                         throw UnboxPathError.invalidValue(nextValue, key)
                     }
 
+                    i = i + 1
                     node = nextNode
                 }
 

--- a/Tests/UnboxTests/UnboxTests.swift
+++ b/Tests/UnboxTests/UnboxTests.swift
@@ -1546,6 +1546,21 @@ class UnboxTests: XCTestCase {
             XCTFail("Unexpected error thrown: \(error)")
         }
     }
+
+    func testUnboxingArrayCustomKeyPathWithSameKeys() {
+        let dictionary: UnboxableDictionary =
+            ["A": ["B": [
+                [["int": 14], ["int": 14], ["int": 14]],
+                [["int": 14], ["int": 20], ["int": 14]]]]]
+
+        do {
+            let unboxed: UnboxTestSimpleMock = try unbox(dictionary: dictionary, atKeyPath: "A.B.1.1")
+            XCTAssertEqual(unboxed.int, 20)
+
+        } catch {
+            XCTFail("Unexpected error thrown: \(error)")
+        }
+    }
     
     func testUnboxingArrayInvalidIndexStartingAtCustomKeyPath() {
         let dictionary: UnboxableDictionary =


### PR DESCRIPTION
These will fix the keyPath when the components have the same name as the last (e.g: “path.0.0” or “path.0.path”)