### PR TITLE
Decrease macOS deployment target to 10.9

### DIFF
--- a/Unbox.podspec
+++ b/Unbox.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author             = { "John Sundell" => "john@sundell.co" }
   s.social_media_url   = "https://twitter.com/johnsundell"
   s.ios.deployment_target = "8.0"
-  s.osx.deployment_target = "10.10"
+  s.osx.deployment_target = "10.9"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/JohnSundell/Unbox.git", :tag => s.version.to_s }

--- a/Unbox.xcodeproj/project.pbxproj
+++ b/Unbox.xcodeproj/project.pbxproj
@@ -1221,7 +1221,7 @@
 				INFOPLIST_FILE = Configs/Unbox.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Unbox-macOS";
 				PRODUCT_NAME = Unbox;
 				SDKROOT = macosx;
@@ -1246,7 +1246,7 @@
 				INFOPLIST_FILE = Configs/Unbox.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Unbox-macOS";
 				PRODUCT_NAME = Unbox;
 				SDKROOT = macosx;


### PR DESCRIPTION
Unbox doesn't seem to use any APIs that are available since 10.10, so it can be used on 10.9 as well.