### PR TITLE
Support Swift 3.2 and Xcode 9

### DIFF
--- a/Sources/Unboxer.swift
+++ b/Sources/Unboxer.swift
@@ -149,7 +149,7 @@ public final class Unboxer {
 
     /// Unbox an optional collection of UnboxableWithContext values by key
     public func unbox<C: UnboxableCollection, V: UnboxableWithContext>(key: String, context: V.UnboxContext, allowInvalidElements: Bool = false) -> C? where C.UnboxValue == V {
-        return try? self.unbox(key: key, context: context, allowInvalidElements: allowInvalidElements)
+        return try? self.unbox(path: .key(key), transform: V.makeCollectionTransform(context: context, allowInvalidElements: allowInvalidElements))
     }
 
     /// Unbox an optional value using a formatter by key
@@ -186,7 +186,7 @@ public final class Unboxer {
 
     /// Unbox an optional collection of UnboxableWithContext values by key path
     public func unbox<C: UnboxableCollection, V: UnboxableWithContext>(keyPath: String, context: V.UnboxContext, allowInvalidElements: Bool = false) -> C? where C.UnboxValue == V {
-        return try? self.unbox(keyPath: keyPath, context: context, allowInvalidElements: allowInvalidElements)
+        return try? self.unbox(path: .keyPath(keyPath), transform: V.makeCollectionTransform(context: context, allowInvalidElements: allowInvalidElements))
     }
 
     /// Unbox an optional value using a formatter by key path


### PR DESCRIPTION
The compiler seems a bit confused when calling a generic, overloaded method that throws with the `try?` syntax, so for now we simply call down to the underlying implementation to make Unbox successfully build & test for Swift 3.1 and Xcode 9.