### PR TITLE
Fix unboxing of key path with same last two components

### DIFF
--- a/Tests/UnboxTests/UnboxTests.swift
+++ b/Tests/UnboxTests/UnboxTests.swift
@@ -1744,6 +1744,29 @@ class UnboxTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+
+    func testKeyPathWithSameLastTwoComponens() {
+        struct Model: Unboxable {
+            let message: String
+
+            init(unboxer: Unboxer) throws {
+                self.message = try unboxer.unbox(keyPath: "message.message")
+            }
+        }
+
+        let dictionary: UnboxableDictionary = [
+            "message": [
+                "message": "value"
+            ]
+        ]
+
+        do {
+            let unboxed: Model = try unbox(dictionary: dictionary)
+            XCTAssertEqual("value", unboxed.message)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }
 
 private func UnboxTestDictionaryWithAllRequiredKeysWithValidValues(nested: Bool) -> UnboxableDictionary {


### PR DESCRIPTION
Hi, I've recently updated Unbox after migrating a project to Swift 3. There's a regression with JSON where last two components of key path are same.

```json
{
	"message": {
		"message": "value"
	}
}
```

I ran performance tests after making changes and performance is pretty much the same.