### PR TITLE
Add support for enums expressible by string or integer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ struct Passenger: Unboxable {
 }
 ```
 
+`UnboxableEnum` also works our-of-the box if your `enum` conforms to custom `ExpressibleByStringLiteral` or `ExpressibleByIntegerLiteral`:
+
+```swift
+enum Profession: CustomStringExpressibleType, RawRepresentable, UnboxableEnum {
+    case developer
+    case astronaut
+}
+```
+
 ### Contextual objects
 
 Sometimes you need to use data other than what's contained in a dictionary during the decoding process. For this, Unbox has support for strongly typed contextual objects that can be made available in the unboxing initializer.

--- a/Sources/UnboxableEnum.swift
+++ b/Sources/UnboxableEnum.swift
@@ -15,3 +15,27 @@ public extension UnboxableEnum {
         return (value as? RawValue).map(self.init)
     }
 }
+
+/// Specialized implementation of `UnboxCompatible` for enums 
+/// that are expressible by String literal.
+public extension UnboxableEnum where RawValue:ExpressibleByStringLiteral{
+    static func unbox(value: Any, allowInvalidCollectionElements: Bool) throws -> Self? {
+        guard let literal = value as? RawValue.StringLiteralType else {
+            return nil
+        }
+        
+        return self.init(rawValue: RawValue(stringLiteral: literal))
+    }
+}
+
+/// Specialized implementation of `UnboxCompatible` for enums
+/// that are expressible by Int literal.
+public extension UnboxableEnum where RawValue:ExpressibleByIntegerLiteral{
+    static func unbox(value: Any, allowInvalidCollectionElements: Bool) throws -> Self? {
+        guard let literal = value as? RawValue.IntegerLiteralType else {
+            return nil
+        }
+        
+        return self.init(rawValue: RawValue(integerLiteral: literal))
+    }
+}


### PR DESCRIPTION
`Unbox` lacks support for enums that have custom `RawRepresentable` that is expressible by literals. 

I needed that in my library [EnumList](https://github.com/polac24/EnumList/), but maybe we could integrate it to `Unbox` library?