### PR TITLE
Fix Xcode 10.2 warnings

### DIFF
--- a/Sources/Unbox/UnboxableCollection.swift
+++ b/Sources/Unbox/UnboxableCollection.swift
@@ -21,7 +21,7 @@ public protocol UnboxableCollection: Collection, UnboxCompatible {
 
 // Default implementation of `UnboxCompatible` for collections
 public extension UnboxableCollection {
-    public static func unbox(value: Any, allowInvalidCollectionElements: Bool) throws -> Self? {
+    static func unbox(value: Any, allowInvalidCollectionElements: Bool) throws -> Self? {
         if let matchingCollection = value as? Self {
             return matchingCollection
         }

--- a/Tests/UnboxTests/UnboxTests.swift
+++ b/Tests/UnboxTests/UnboxTests.swift
@@ -1803,7 +1803,10 @@ private enum UnboxTestEnum: Int, UnboxableEnum {
 }
 
 private struct UnboxTestDictionaryKey: UnboxableKey, Hashable {
-    var hashValue: Int { return self.key.hashValue }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.key)
+    }
     
     let key: String
     


### PR DESCRIPTION
This PR will fix the following warnings in Xcode 10.2:

```
Unbox/Sources/Unbox/UnboxableCollection.swift:24:5: 'public' modifier is redundant for static method declared in a public extension
```

```
Unbox/Tests/UnboxTests/UnboxTests.swift:1806:9: 'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'UnboxTestDictionaryKey' to 'Hashable' by implementing 'hash(into:)' instead
```